### PR TITLE
Reader: paginated/scrolled mode parity (PDF + EPUB) with shared settings

### DIFF
--- a/docs/superpowers/plans/2026-04-19-reader-paginated-mode.md
+++ b/docs/superpowers/plans/2026-04-19-reader-paginated-mode.md
@@ -1,0 +1,1190 @@
+# Reader Paginated Mode — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add paginated mode to the PDF reader, bring EPUB to feature parity with shared controls (flow / spread / animation / per-input toggles / RTL direction), and unify the settings surface across both. Includes a small bug fix so the EPUB reader doesn't load for books that have no EPUB format (already committed in spec commit).
+
+**Architecture:** A new `PaginatedViewport.svelte` wraps both readers and owns flow/spread/animation/input handling. A `useReaderInputs.svelte.ts` rune centralizes tap-zone / swipe / keyboard handling. A new `reader-settings.ts` helper owns the shared `ReaderSettings` schema, defaults, and `localStorage` persistence (extending the existing `nexus-reader-settings` key).
+
+**Tech Stack:** SvelteKit 5 (runes), TypeScript, foliate-js (EPUB), pdfjs-dist (PDF), Vitest, Tailwind.
+
+**Spec:** `docs/superpowers/specs/2026-04-19-reader-paginated-mode-design.md`
+
+**Branch:** `feature/reader-paginated-mode` (worktree at `.worktrees/reader-paginated`)
+
+**Closes:** #61
+
+---
+
+## File Map
+
+**Create:**
+- `src/lib/components/books/reader-settings.ts` — `ReaderSettings` type, defaults, `loadReaderSettings()`, `persistReaderSettings()`, `resolveSpread()`, theme/font/margin enums.
+- `src/lib/components/books/__tests__/reader-settings.test.ts` — vitest covering load/persist/defaults/resolve.
+- `src/lib/components/books/useReaderInputs.svelte.ts` — rune that exposes tap-zone / swipe / keyboard handlers, respecting `inputs.*` and `direction`.
+- `src/lib/components/books/__tests__/useReaderInputs.test.ts` — vitest covering hit detection, swipe threshold, RTL flip, keyboard mapping, per-input enable/disable.
+- `src/lib/components/books/PaginatedViewport.svelte` — wrapper component, owns flow/spread/animation/input wiring, passes `goPrev`/`goNext`/`pageOffset` to children via Svelte snippets and bindable props.
+- `src/lib/components/books/ReaderSettingsPanel.svelte` — shared settings UI (theme, font, font-size, line-height, margins, text-align, flow, spread, animation, inputs, direction).
+
+**Modify:**
+- `src/lib/components/books/BookReader.svelte` — adopt `reader-settings.ts`, render `<ReaderSettingsPanel>` in its drawer, pass settings to `<PaginatedViewport>`, hook foliate-js renderer to viewport's prev/next/flow/direction.
+- `src/lib/components/books/PdfReader.svelte` — adopt `reader-settings.ts`, render `<ReaderSettingsPanel>` in its drawer, wrap with `<PaginatedViewport>`, render only current page(s) when `flow === 'paginated'`, advance via viewport callbacks. Existing single/dual `spreadMode` becomes the `spread` setting.
+- `src/lib/components/books/KeyboardShortcuts.svelte` — make format-agnostic (currently EPUB-only); export keymap so PDF reader can adopt the same shortcuts. (If file is too tightly coupled to EPUB, the keyboard half of `useReaderInputs` may obviate this file — in that case Task 9 deletes it.)
+
+**Already committed (in spec commit `050e489`):**
+- `src/routes/books/read/[id]/+page.server.ts` — books-read 500 fix + format default fallback.
+
+---
+
+## Task 1: Reader settings module — schema, defaults, persistence
+
+**Files:**
+- Create: `src/lib/components/books/reader-settings.ts`
+- Create: `src/lib/components/books/__tests__/reader-settings.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/lib/components/books/__tests__/reader-settings.test.ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+	DEFAULT_READER_SETTINGS,
+	loadReaderSettings,
+	persistReaderSettings,
+	resolveSpread,
+	type ReaderSettings
+} from '../reader-settings';
+
+describe('reader-settings', () => {
+	beforeEach(() => {
+		// vitest provides a happy-dom localStorage by default
+		localStorage.clear();
+	});
+
+	it('returns defaults when nothing is stored', () => {
+		expect(loadReaderSettings()).toEqual(DEFAULT_READER_SETTINGS);
+	});
+
+	it('round-trips persisted settings', () => {
+		const patch: Partial<ReaderSettings> = {
+			flow: 'scrolled',
+			spread: 'dual',
+			pageAnimation: 'fade',
+			direction: 'rtl',
+			inputs: { tapZones: false, swipe: true, keyboard: true }
+		};
+		persistReaderSettings(patch);
+		const loaded = loadReaderSettings();
+		expect(loaded.flow).toBe('scrolled');
+		expect(loaded.spread).toBe('dual');
+		expect(loaded.pageAnimation).toBe('fade');
+		expect(loaded.direction).toBe('rtl');
+		expect(loaded.inputs.tapZones).toBe(false);
+	});
+
+	it('preserves unrelated existing fields when persisting a partial patch', () => {
+		persistReaderSettings({ fontSize: 22, theme: 'sepia' as ReaderSettings['theme'] });
+		persistReaderSettings({ flow: 'scrolled' });
+		const loaded = loadReaderSettings();
+		expect(loaded.fontSize).toBe(22);
+		expect(loaded.theme).toBe('sepia');
+		expect(loaded.flow).toBe('scrolled');
+	});
+
+	it('falls back to defaults for missing keys in stored JSON', () => {
+		localStorage.setItem('nexus-reader-settings', JSON.stringify({ flow: 'scrolled' }));
+		const loaded = loadReaderSettings();
+		expect(loaded.flow).toBe('scrolled');
+		expect(loaded.spread).toBe(DEFAULT_READER_SETTINGS.spread);
+		expect(loaded.inputs).toEqual(DEFAULT_READER_SETTINGS.inputs);
+	});
+
+	it('coerces invalid stored values back to defaults', () => {
+		localStorage.setItem('nexus-reader-settings', JSON.stringify({ flow: 'banana', spread: 42 }));
+		const loaded = loadReaderSettings();
+		expect(loaded.flow).toBe(DEFAULT_READER_SETTINGS.flow);
+		expect(loaded.spread).toBe(DEFAULT_READER_SETTINGS.spread);
+	});
+
+	describe('resolveSpread', () => {
+		it('returns single below 768px when auto', () => {
+			expect(resolveSpread('auto', 600)).toBe('single');
+		});
+		it('returns dual at or above 768px when auto', () => {
+			expect(resolveSpread('auto', 1024)).toBe('dual');
+		});
+		it('respects explicit single regardless of width', () => {
+			expect(resolveSpread('single', 1920)).toBe('single');
+		});
+		it('respects explicit dual regardless of width', () => {
+			expect(resolveSpread('dual', 320)).toBe('dual');
+		});
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd .worktrees/reader-paginated
+pnpm vitest run src/lib/components/books/__tests__/reader-settings.test.ts
+```
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement the module**
+
+```ts
+// src/lib/components/books/reader-settings.ts
+export type ReaderThemeName = 'light' | 'dark' | 'sepia' | 'night';
+export type FontFamilyName = 'serif' | 'sans' | 'mono' | 'dyslexic';
+export type MarginName = 'narrow' | 'normal' | 'wide';
+
+export interface ReaderSettings {
+	theme: ReaderThemeName;
+	fontFamily: FontFamilyName;
+	fontSize: number;
+	lineHeight: number;
+	margins: MarginName;
+	textAlign: 'start' | 'justify';
+	flow: 'paginated' | 'scrolled';
+	spread: 'auto' | 'single' | 'dual';
+	pageAnimation: 'slide' | 'fade' | 'none';
+	inputs: {
+		tapZones: boolean;
+		swipe: boolean;
+		keyboard: boolean;
+	};
+	direction: 'ltr' | 'rtl';
+}
+
+export const DEFAULT_READER_SETTINGS: ReaderSettings = {
+	theme: 'dark',
+	fontFamily: 'serif',
+	fontSize: 18,
+	lineHeight: 1.5,
+	margins: 'normal',
+	textAlign: 'start',
+	flow: 'paginated',
+	spread: 'auto',
+	pageAnimation: 'slide',
+	inputs: { tapZones: true, swipe: true, keyboard: true },
+	direction: 'ltr'
+};
+
+const STORAGE_KEY = 'nexus-reader-settings';
+
+const FLOW_VALUES = new Set(['paginated', 'scrolled'] as const);
+const SPREAD_VALUES = new Set(['auto', 'single', 'dual'] as const);
+const ANIM_VALUES = new Set(['slide', 'fade', 'none'] as const);
+const DIR_VALUES = new Set(['ltr', 'rtl'] as const);
+const ALIGN_VALUES = new Set(['start', 'justify'] as const);
+const THEME_VALUES = new Set(['light', 'dark', 'sepia', 'night'] as const);
+const FONT_VALUES = new Set(['serif', 'sans', 'mono', 'dyslexic'] as const);
+const MARGIN_VALUES = new Set(['narrow', 'normal', 'wide'] as const);
+
+function pick<T extends string>(value: unknown, allowed: Set<T>, fallback: T): T {
+	return typeof value === 'string' && allowed.has(value as T) ? (value as T) : fallback;
+}
+
+function pickNumber(value: unknown, fallback: number, min: number, max: number): number {
+	if (typeof value !== 'number' || !Number.isFinite(value)) return fallback;
+	if (value < min || value > max) return fallback;
+	return value;
+}
+
+function pickBool(value: unknown, fallback: boolean): boolean {
+	return typeof value === 'boolean' ? value : fallback;
+}
+
+function coerce(raw: unknown): ReaderSettings {
+	const r = (raw && typeof raw === 'object' ? raw : {}) as Record<string, unknown>;
+	const inputsRaw = (r.inputs && typeof r.inputs === 'object' ? r.inputs : {}) as Record<string, unknown>;
+	return {
+		theme: pick(r.theme, THEME_VALUES, DEFAULT_READER_SETTINGS.theme),
+		fontFamily: pick(r.fontFamily, FONT_VALUES, DEFAULT_READER_SETTINGS.fontFamily),
+		fontSize: pickNumber(r.fontSize, DEFAULT_READER_SETTINGS.fontSize, 10, 36),
+		lineHeight: pickNumber(r.lineHeight, DEFAULT_READER_SETTINGS.lineHeight, 1.0, 2.5),
+		margins: pick(r.margins, MARGIN_VALUES, DEFAULT_READER_SETTINGS.margins),
+		textAlign: pick(r.textAlign, ALIGN_VALUES, DEFAULT_READER_SETTINGS.textAlign),
+		flow: pick(r.flow, FLOW_VALUES, DEFAULT_READER_SETTINGS.flow),
+		spread: pick(r.spread, SPREAD_VALUES, DEFAULT_READER_SETTINGS.spread),
+		pageAnimation: pick(r.pageAnimation, ANIM_VALUES, DEFAULT_READER_SETTINGS.pageAnimation),
+		inputs: {
+			tapZones: pickBool(inputsRaw.tapZones, DEFAULT_READER_SETTINGS.inputs.tapZones),
+			swipe: pickBool(inputsRaw.swipe, DEFAULT_READER_SETTINGS.inputs.swipe),
+			keyboard: pickBool(inputsRaw.keyboard, DEFAULT_READER_SETTINGS.inputs.keyboard)
+		},
+		direction: pick(r.direction, DIR_VALUES, DEFAULT_READER_SETTINGS.direction)
+	};
+}
+
+export function loadReaderSettings(): ReaderSettings {
+	if (typeof localStorage === 'undefined') return { ...DEFAULT_READER_SETTINGS };
+	try {
+		const raw = localStorage.getItem(STORAGE_KEY);
+		if (!raw) return { ...DEFAULT_READER_SETTINGS };
+		return coerce(JSON.parse(raw));
+	} catch {
+		return { ...DEFAULT_READER_SETTINGS };
+	}
+}
+
+export function persistReaderSettings(patch: Partial<ReaderSettings>): void {
+	if (typeof localStorage === 'undefined') return;
+	const current = loadReaderSettings();
+	const next: ReaderSettings = {
+		...current,
+		...patch,
+		inputs: { ...current.inputs, ...(patch.inputs ?? {}) }
+	};
+	try {
+		localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+	} catch {
+		/* quota or privacy mode — ignore */
+	}
+}
+
+const SPREAD_BREAKPOINT_PX = 768;
+
+export function resolveSpread(spread: ReaderSettings['spread'], viewportWidth: number): 'single' | 'dual' {
+	if (spread === 'single' || spread === 'dual') return spread;
+	return viewportWidth >= SPREAD_BREAKPOINT_PX ? 'dual' : 'single';
+}
+```
+
+- [ ] **Step 4: Run tests, expect green**
+
+```bash
+pnpm vitest run src/lib/components/books/__tests__/reader-settings.test.ts
+```
+Expected: 9 passing.
+
+- [ ] **Step 5: Run typecheck**
+
+```bash
+pnpm check
+```
+Expected: 0 errors (warnings unrelated to this change are OK).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/components/books/reader-settings.ts \
+        src/lib/components/books/__tests__/reader-settings.test.ts
+git commit -m "feat(reader): shared ReaderSettings module with localStorage persistence (#61)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: useReaderInputs rune — tap zones, swipe, keyboard
+
+**Files:**
+- Create: `src/lib/components/books/useReaderInputs.svelte.ts`
+- Create: `src/lib/components/books/__tests__/useReaderInputs.test.ts`
+
+The rune exposes a small object with three things: a `pointerHandlers` set you spread onto the tap-zone overlay, a `touchHandlers` set you spread onto the swipe surface, and a side-effect for keyboard listeners that runs in an `$effect`. RTL mode flips the prev/next mapping for all three.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/lib/components/books/__tests__/useReaderInputs.test.ts
+import { describe, it, expect, vi } from 'vitest';
+import { hitZone, isHorizontalSwipe, mapKeyToAction } from '../useReaderInputs.svelte';
+
+describe('useReaderInputs helpers', () => {
+	describe('hitZone', () => {
+		it('maps left third to prev', () => {
+			expect(hitZone(50, 1000)).toBe('prev');
+		});
+		it('maps middle third to toggleUI', () => {
+			expect(hitZone(500, 1000)).toBe('toggleUI');
+		});
+		it('maps right third to next', () => {
+			expect(hitZone(900, 1000)).toBe('next');
+		});
+		it('handles small viewports', () => {
+			expect(hitZone(100, 360)).toBe('prev');
+			expect(hitZone(180, 360)).toBe('toggleUI');
+			expect(hitZone(300, 360)).toBe('next');
+		});
+	});
+
+	describe('isHorizontalSwipe', () => {
+		it('returns prev for rightward swipe past threshold', () => {
+			expect(isHorizontalSwipe({ dx: 80, dy: 10 })).toBe('prev');
+		});
+		it('returns next for leftward swipe past threshold', () => {
+			expect(isHorizontalSwipe({ dx: -80, dy: 10 })).toBe('next');
+		});
+		it('returns null when below threshold', () => {
+			expect(isHorizontalSwipe({ dx: 30, dy: 5 })).toBeNull();
+		});
+		it('returns null when vertical travel dominates', () => {
+			expect(isHorizontalSwipe({ dx: 60, dy: 200 })).toBeNull();
+		});
+	});
+
+	describe('mapKeyToAction', () => {
+		it('maps ArrowLeft to prev', () => {
+			expect(mapKeyToAction('ArrowLeft')).toBe('prev');
+		});
+		it('maps ArrowRight to next', () => {
+			expect(mapKeyToAction('ArrowRight')).toBe('next');
+		});
+		it('maps PageUp to prev, PageDown and Space to next', () => {
+			expect(mapKeyToAction('PageUp')).toBe('prev');
+			expect(mapKeyToAction('PageDown')).toBe('next');
+			expect(mapKeyToAction(' ')).toBe('next');
+		});
+		it('returns null for irrelevant keys', () => {
+			expect(mapKeyToAction('a')).toBeNull();
+			expect(mapKeyToAction('Enter')).toBeNull();
+		});
+	});
+
+	describe('flipForRtl', () => {
+		it('swaps prev and next when direction is rtl', async () => {
+			const { flipForRtl } = await import('../useReaderInputs.svelte');
+			expect(flipForRtl('prev', 'rtl')).toBe('next');
+			expect(flipForRtl('next', 'rtl')).toBe('prev');
+			expect(flipForRtl('toggleUI', 'rtl')).toBe('toggleUI');
+		});
+		it('passes through when direction is ltr', async () => {
+			const { flipForRtl } = await import('../useReaderInputs.svelte');
+			expect(flipForRtl('prev', 'ltr')).toBe('prev');
+			expect(flipForRtl('next', 'ltr')).toBe('next');
+		});
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pnpm vitest run src/lib/components/books/__tests__/useReaderInputs.test.ts
+```
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement the rune + helpers**
+
+```ts
+// src/lib/components/books/useReaderInputs.svelte.ts
+import type { ReaderSettings } from './reader-settings';
+
+export type ReaderAction = 'prev' | 'next' | 'toggleUI';
+
+const SWIPE_MIN_PX = 50;
+const SWIPE_VERTICAL_RATIO = 2; // |dx| must be > 2*|dy|
+
+export function hitZone(x: number, width: number): ReaderAction {
+	const third = width / 3;
+	if (x < third) return 'prev';
+	if (x < 2 * third) return 'toggleUI';
+	return 'next';
+}
+
+export function isHorizontalSwipe({ dx, dy }: { dx: number; dy: number }): ReaderAction | null {
+	if (Math.abs(dx) < SWIPE_MIN_PX) return null;
+	if (Math.abs(dx) <= Math.abs(dy) * SWIPE_VERTICAL_RATIO) return null;
+	return dx > 0 ? 'prev' : 'next';
+}
+
+export function mapKeyToAction(key: string): ReaderAction | null {
+	switch (key) {
+		case 'ArrowLeft':
+		case 'PageUp':
+			return 'prev';
+		case 'ArrowRight':
+		case 'PageDown':
+		case ' ':
+			return 'next';
+		default:
+			return null;
+	}
+}
+
+export function flipForRtl<A extends ReaderAction>(action: A, direction: ReaderSettings['direction']): A {
+	if (direction !== 'rtl') return action;
+	if (action === 'prev') return 'next' as A;
+	if (action === 'next') return 'prev' as A;
+	return action;
+}
+
+interface UseInputsArgs {
+	getSettings: () => Pick<ReaderSettings, 'inputs' | 'direction'>;
+	onPrev: () => void;
+	onNext: () => void;
+	onToggleUI: () => void;
+}
+
+export function useReaderInputs(args: UseInputsArgs) {
+	const dispatch = (action: ReaderAction) => {
+		const { direction } = args.getSettings();
+		const final = flipForRtl(action, direction);
+		if (final === 'prev') args.onPrev();
+		else if (final === 'next') args.onNext();
+		else if (final === 'toggleUI') args.onToggleUI();
+	};
+
+	// Tap-zone handlers (spread onto an absolutely-positioned overlay div).
+	const tapHandlers = {
+		onpointerup(e: PointerEvent) {
+			if (!args.getSettings().inputs.tapZones) return;
+			const target = e.currentTarget as HTMLElement;
+			const rect = target.getBoundingClientRect();
+			dispatch(hitZone(e.clientX - rect.left, rect.width));
+		}
+	};
+
+	// Swipe handlers (spread onto the page surface).
+	let touchStart: { x: number; y: number } | null = null;
+	const swipeHandlers = {
+		ontouchstart(e: TouchEvent) {
+			if (!args.getSettings().inputs.swipe) return;
+			const t = e.changedTouches[0];
+			touchStart = { x: t.clientX, y: t.clientY };
+		},
+		ontouchend(e: TouchEvent) {
+			if (!args.getSettings().inputs.swipe || !touchStart) return;
+			const t = e.changedTouches[0];
+			const dx = t.clientX - touchStart.x;
+			const dy = t.clientY - touchStart.y;
+			touchStart = null;
+			const action = isHorizontalSwipe({ dx, dy });
+			if (action) dispatch(action);
+		}
+	};
+
+	// Keyboard listener — caller wires this in an $effect.
+	function attachKeyboard(target: Window | HTMLElement = window): () => void {
+		const onKey = (e: KeyboardEvent) => {
+			if (!args.getSettings().inputs.keyboard) return;
+			const action = mapKeyToAction(e.key);
+			if (!action) return;
+			e.preventDefault();
+			dispatch(action);
+		};
+		target.addEventListener('keydown', onKey as EventListener);
+		return () => target.removeEventListener('keydown', onKey as EventListener);
+	}
+
+	return { tapHandlers, swipeHandlers, attachKeyboard };
+}
+```
+
+- [ ] **Step 4: Run tests, expect green**
+
+```bash
+pnpm vitest run src/lib/components/books/__tests__/useReaderInputs.test.ts
+```
+Expected: 13 passing.
+
+- [ ] **Step 5: Typecheck**
+
+```bash
+pnpm check
+```
+Expected: 0 errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/components/books/useReaderInputs.svelte.ts \
+        src/lib/components/books/__tests__/useReaderInputs.test.ts
+git commit -m "feat(reader): useReaderInputs rune for tap/swipe/keyboard (#61)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: PaginatedViewport.svelte — generic wrapper
+
+**Files:**
+- Create: `src/lib/components/books/PaginatedViewport.svelte`
+
+The wrapper renders an absolutely-positioned tap-zone overlay above its child snippet, owns the swipe surface, attaches the keyboard listener, and surfaces a small reactive context the child can read for `effectiveSpread` (resolved from `auto`).
+
+- [ ] **Step 1: Implement**
+
+```svelte
+<!-- src/lib/components/books/PaginatedViewport.svelte -->
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import type { Snippet } from 'svelte';
+	import type { ReaderSettings } from './reader-settings';
+	import { resolveSpread } from './reader-settings';
+	import { useReaderInputs } from './useReaderInputs.svelte';
+
+	interface Props {
+		settings: ReaderSettings;
+		onPrev: () => void;
+		onNext: () => void;
+		onToggleUI: () => void;
+		/** Child renders the actual reader content. Receives effectiveSpread + animationKey. */
+		children: Snippet<[{ effectiveSpread: 'single' | 'dual'; animationKey: number }]>;
+	}
+
+	let { settings, onPrev, onNext, onToggleUI, children }: Props = $props();
+
+	let containerEl = $state<HTMLDivElement | undefined>();
+	let viewportWidth = $state<number>(typeof window !== 'undefined' ? window.innerWidth : 1024);
+	let animationKey = $state<number>(0); // Bumped on prev/next so children can re-trigger animations.
+
+	const effectiveSpread = $derived(resolveSpread(settings.spread, viewportWidth));
+
+	const inputs = useReaderInputs({
+		getSettings: () => settings,
+		onPrev: () => { animationKey++; onPrev(); },
+		onNext: () => { animationKey++; onNext(); },
+		onToggleUI
+	});
+
+	onMount(() => {
+		const onResize = () => { viewportWidth = window.innerWidth; };
+		window.addEventListener('resize', onResize);
+		const detach = inputs.attachKeyboard(window);
+		return () => {
+			window.removeEventListener('resize', onResize);
+			detach();
+		};
+	});
+
+	const animClass = $derived.by(() => {
+		if (settings.flow !== 'paginated') return '';
+		switch (settings.pageAnimation) {
+			case 'slide': return 'reader-anim-slide';
+			case 'fade': return 'reader-anim-fade';
+			default: return '';
+		}
+	});
+</script>
+
+<div
+	bind:this={containerEl}
+	class="reader-viewport {animClass}"
+	data-flow={settings.flow}
+	data-spread={effectiveSpread}
+	data-direction={settings.direction}
+	{...inputs.swipeHandlers}
+>
+	{#key animationKey}
+		<div class="reader-page-layer">
+			{@render children({ effectiveSpread, animationKey })}
+		</div>
+	{/key}
+	<!-- Tap-zone overlay only when paginated + tapZones enabled -->
+	{#if settings.flow === 'paginated' && settings.inputs.tapZones}
+		<div class="reader-tap-overlay" {...inputs.tapHandlers} aria-hidden="true"></div>
+	{/if}
+</div>
+
+<style>
+	.reader-viewport {
+		position: relative;
+		width: 100%;
+		height: 100%;
+		overflow: hidden;
+		touch-action: pan-y; /* allow vertical scroll in scrolled mode, swipe in paginated */
+	}
+	.reader-viewport[data-flow='scrolled'] {
+		overflow-y: auto;
+	}
+	.reader-page-layer {
+		width: 100%;
+		height: 100%;
+	}
+	.reader-tap-overlay {
+		position: absolute;
+		inset: 0;
+		z-index: 5;
+		background: transparent;
+	}
+	.reader-anim-slide .reader-page-layer {
+		animation: reader-slide-in 220ms ease-out;
+	}
+	.reader-anim-fade .reader-page-layer {
+		animation: reader-fade-in 150ms ease-out;
+	}
+	@keyframes reader-slide-in {
+		from { transform: translateX(20%); opacity: 0; }
+		to { transform: translateX(0); opacity: 1; }
+	}
+	@keyframes reader-fade-in {
+		from { opacity: 0; }
+		to { opacity: 1; }
+	}
+</style>
+```
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+pnpm check
+```
+Expected: 0 errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/components/books/PaginatedViewport.svelte
+git commit -m "feat(reader): PaginatedViewport wrapper component (#61)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: ReaderSettingsPanel.svelte — shared settings UI
+
+**Files:**
+- Create: `src/lib/components/books/ReaderSettingsPanel.svelte`
+
+A single component rendering all reader settings controls. Used inside both readers' existing right-side drawers. Uses `bindable` so the parent owns the `settings` object and wires `persistReaderSettings()` in an `$effect` once.
+
+- [ ] **Step 1: Implement**
+
+```svelte
+<!-- src/lib/components/books/ReaderSettingsPanel.svelte -->
+<script lang="ts">
+	import type { ReaderSettings } from './reader-settings';
+
+	interface Props {
+		settings: ReaderSettings;
+		/** Hide PDF-irrelevant controls (theme/font/textAlign) when used in PDF reader. */
+		variant?: 'epub' | 'pdf';
+	}
+
+	let { settings = $bindable(), variant = 'epub' }: Props = $props();
+
+	const flowOptions: Array<{ value: ReaderSettings['flow']; label: string }> = [
+		{ value: 'paginated', label: 'Paginated' },
+		{ value: 'scrolled', label: 'Scrolled' }
+	];
+	const spreadOptions: Array<{ value: ReaderSettings['spread']; label: string }> = [
+		{ value: 'auto', label: 'Auto' },
+		{ value: 'single', label: 'Single' },
+		{ value: 'dual', label: 'Dual' }
+	];
+	const animOptions: Array<{ value: ReaderSettings['pageAnimation']; label: string }> = [
+		{ value: 'slide', label: 'Slide' },
+		{ value: 'fade', label: 'Fade' },
+		{ value: 'none', label: 'None' }
+	];
+	const dirOptions: Array<{ value: ReaderSettings['direction']; label: string }> = [
+		{ value: 'ltr', label: 'Left → Right' },
+		{ value: 'rtl', label: 'Right → Left' }
+	];
+</script>
+
+<div class="reader-settings space-y-5">
+	<section>
+		<h3 class="settings-heading">Page flow</h3>
+		<div class="settings-row">
+			{#each flowOptions as opt}
+				<button
+					type="button"
+					class="settings-pill"
+					class:settings-pill--active={settings.flow === opt.value}
+					onclick={() => { settings.flow = opt.value; }}
+				>{opt.label}</button>
+			{/each}
+		</div>
+	</section>
+
+	<section>
+		<h3 class="settings-heading">Spread</h3>
+		<div class="settings-row">
+			{#each spreadOptions as opt}
+				<button
+					type="button"
+					class="settings-pill"
+					class:settings-pill--active={settings.spread === opt.value}
+					onclick={() => { settings.spread = opt.value; }}
+				>{opt.label}</button>
+			{/each}
+		</div>
+		<p class="settings-hint">Auto picks dual on tablets/desktop, single on phones.</p>
+	</section>
+
+	<section>
+		<h3 class="settings-heading">Page animation</h3>
+		<div class="settings-row">
+			{#each animOptions as opt}
+				<button
+					type="button"
+					class="settings-pill"
+					class:settings-pill--active={settings.pageAnimation === opt.value}
+					onclick={() => { settings.pageAnimation = opt.value; }}
+				>{opt.label}</button>
+			{/each}
+		</div>
+	</section>
+
+	<section>
+		<h3 class="settings-heading">Inputs</h3>
+		<label class="settings-toggle">
+			<input type="checkbox" bind:checked={settings.inputs.tapZones} />
+			<span>Tap zones (left/middle/right)</span>
+		</label>
+		<label class="settings-toggle">
+			<input type="checkbox" bind:checked={settings.inputs.swipe} />
+			<span>Swipe</span>
+		</label>
+		<label class="settings-toggle">
+			<input type="checkbox" bind:checked={settings.inputs.keyboard} />
+			<span>Keyboard (← → PgUp PgDn Space)</span>
+		</label>
+	</section>
+
+	<section>
+		<h3 class="settings-heading">Direction</h3>
+		<div class="settings-row">
+			{#each dirOptions as opt}
+				<button
+					type="button"
+					class="settings-pill"
+					class:settings-pill--active={settings.direction === opt.value}
+					onclick={() => { settings.direction = opt.value; }}
+				>{opt.label}</button>
+			{/each}
+		</div>
+	</section>
+
+	{#if variant === 'epub'}
+		<section>
+			<h3 class="settings-heading">Font size</h3>
+			<input
+				type="range" min="12" max="32" step="1"
+				bind:value={settings.fontSize}
+				class="w-full"
+			/>
+			<p class="settings-hint">{settings.fontSize}px</p>
+		</section>
+	{/if}
+</div>
+
+<style>
+	.settings-heading {
+		font-size: 0.7rem;
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+		color: rgb(255 247 230 / 0.45);
+		margin-bottom: 0.5rem;
+	}
+	.settings-row {
+		display: flex;
+		gap: 0.4rem;
+	}
+	.settings-pill {
+		flex: 1;
+		padding: 0.5rem 0.75rem;
+		border-radius: 0.6rem;
+		border: 1px solid rgb(255 247 230 / 0.08);
+		font-size: 0.75rem;
+		color: rgb(255 247 230 / 0.5);
+		background: transparent;
+		transition: all 120ms ease;
+	}
+	.settings-pill:hover {
+		color: rgb(255 247 230 / 0.7);
+		border-color: rgb(255 247 230 / 0.2);
+	}
+	.settings-pill--active {
+		background: var(--color-accent, #d4b483);
+		color: #1a1410;
+		border-color: var(--color-accent, #d4b483);
+	}
+	.settings-toggle {
+		display: flex;
+		align-items: center;
+		gap: 0.6rem;
+		font-size: 0.85rem;
+		color: rgb(255 247 230 / 0.7);
+		padding: 0.35rem 0;
+	}
+	.settings-hint {
+		font-size: 0.7rem;
+		color: rgb(255 247 230 / 0.4);
+		margin-top: 0.4rem;
+	}
+</style>
+```
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+pnpm check
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/components/books/ReaderSettingsPanel.svelte
+git commit -m "feat(reader): ReaderSettingsPanel shared settings UI (#61)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Wire BookReader to shared settings + viewport
+
+**Files:**
+- Modify: `src/lib/components/books/BookReader.svelte`
+
+The current EPUB reader has `flow`, `theme`, `fontFamily`, etc. as discrete `$state` variables and its own `loadSettings()` / `persistSettings()` using the same `nexus-reader-settings` key. Replace those with `loadReaderSettings()` / `persistReaderSettings()` calls and a single `settings` object. Render `<ReaderSettingsPanel>` inside the existing settings drawer (replacing the bespoke flow toggle at lines ~995-1010 and any duplicated controls). Pass `settings`, `onPrev=() => view.prev()`, `onNext=() => view.next()`, `onToggleUI=...` to `<PaginatedViewport>` wrapping the foliate-js view container.
+
+The foliate-js renderer's `setAttribute('flow', ...)` continues to drive the underlying paginated layout — call it inside an `$effect` whenever `settings.flow` changes (replaces lines 687-691).
+
+- [ ] **Step 1: Read current state**
+
+```bash
+grep -n "loadSettings\|persistSettings\|let flow\|let readerTheme\|let fontFamily\|setAttribute('flow'" src/lib/components/books/BookReader.svelte
+```
+
+Note the line numbers; you'll be replacing the existing settings state declarations and the existing settings drawer markup.
+
+- [ ] **Step 2: Add imports + replace settings state with single object**
+
+Replace the discrete `let theme = $state(...)` etc. block with:
+
+```ts
+import { loadReaderSettings, persistReaderSettings, type ReaderSettings } from './reader-settings';
+import PaginatedViewport from './PaginatedViewport.svelte';
+import ReaderSettingsPanel from './ReaderSettingsPanel.svelte';
+
+let settings = $state<ReaderSettings>(loadReaderSettings());
+$effect(() => { persistReaderSettings(settings); });
+
+// Convenience aliases for existing template bindings — keep until the template is updated.
+const readerTheme = $derived(settings.theme);
+const fontFamily = $derived(settings.fontFamily);
+const fontSize = $derived(settings.fontSize);
+const lineHeight = $derived(settings.lineHeight);
+const margins = $derived(settings.margins);
+const textAlign = $derived(settings.textAlign);
+const flow = $derived(settings.flow);
+```
+
+Delete the old `loadSettings()` / `persistSettings()` functions (lines ~148-170) and the discrete `$state` declarations.
+
+- [ ] **Step 3: Wrap the foliate-js host in PaginatedViewport**
+
+Locate the `<div>` that hosts the foliate-js view (typically the one bound to `viewEl` or similar). Wrap it:
+
+```svelte
+<PaginatedViewport
+	{settings}
+	onPrev={() => view?.prev()}
+	onNext={() => view?.next()}
+	onToggleUI={() => { settingsOpen = !settingsOpen; }}
+>
+	{#snippet children()}
+		<div bind:this={viewEl} class="absolute inset-0"></div>
+	{/snippet}
+</PaginatedViewport>
+```
+
+(Field names like `view`, `viewEl`, `settingsOpen` may differ slightly — preserve whatever this file already uses.)
+
+- [ ] **Step 4: Replace the in-drawer settings markup with the shared panel**
+
+Inside the existing right-side settings drawer (`<aside>` around line 1018), replace the bespoke flow buttons + any controls now owned by the shared panel with:
+
+```svelte
+<ReaderSettingsPanel bind:settings variant="epub" />
+```
+
+Keep theme/font picker UI that's not yet in the shared panel — those remain in BookReader for now (the panel only renders the new + flow controls in v1).
+
+- [ ] **Step 5: Drive foliate flow via effect**
+
+Replace the existing `flow`-change effect (lines ~687-691) with:
+
+```ts
+$effect(() => {
+	if (!view?.renderer) return;
+	view.renderer.setAttribute('flow', settings.flow);
+	view.renderer.setAttribute('dir', settings.direction);
+});
+```
+
+- [ ] **Step 6: Typecheck**
+
+```bash
+pnpm check
+```
+Expected: 0 errors.
+
+- [ ] **Step 7: Manual smoke**
+
+```bash
+pnpm dev
+```
+
+In a browser at the dev URL:
+- Open a book; verify it loads in paginated mode with the new shared panel visible
+- Toggle Flow → Scrolled, verify behavior changes
+- Toggle Direction → RTL, swipe; verify swipe direction inverts
+- Reload page; settings persist
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/lib/components/books/BookReader.svelte
+git commit -m "feat(reader): wire BookReader to shared settings + viewport (#61)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Add paginated mode to PdfReader
+
+**Files:**
+- Modify: `src/lib/components/books/PdfReader.svelte`
+
+PdfReader currently renders pages into a vertically scrolling container with `overflow-y: auto`. To add paginated mode, render only the visible page(s) at fit-to-viewport sizing and let prev/next callbacks change `currentPage`.
+
+- [ ] **Step 1: Adopt shared settings**
+
+Add at top of `<script>`:
+
+```ts
+import { loadReaderSettings, persistReaderSettings, resolveSpread, type ReaderSettings } from './reader-settings';
+import PaginatedViewport from './PaginatedViewport.svelte';
+import ReaderSettingsPanel from './ReaderSettingsPanel.svelte';
+
+let settings = $state<ReaderSettings>(loadReaderSettings());
+$effect(() => { persistReaderSettings(settings); });
+```
+
+Remove the existing `let spreadMode = $state<'single' | 'dual'>('single');` — replace its usages with `resolveSpread(settings.spread, viewportWidth)` (capture `viewportWidth` from the wrapper or a local `$state` updated on resize).
+
+- [ ] **Step 2: Wrap rendered pages in PaginatedViewport**
+
+Replace the outer scroll container with:
+
+```svelte
+<PaginatedViewport
+	{settings}
+	onPrev={goPrevPage}
+	onNext={goNextPage}
+	onToggleUI={() => { settingsOpen = !settingsOpen; }}
+>
+	{#snippet children({ effectiveSpread })}
+		<div class="pdf-pages" data-flow={settings.flow} data-spread={effectiveSpread}>
+			{#if settings.flow === 'paginated'}
+				<!-- Render only currentPage (and currentPage+1 if dual) -->
+				<canvas data-page={currentPage} bind:this={canvasRefs[currentPage]}></canvas>
+				{#if effectiveSpread === 'dual' && currentPage + 1 <= totalPages}
+					<canvas data-page={currentPage + 1} bind:this={canvasRefs[currentPage + 1]}></canvas>
+				{/if}
+			{:else}
+				<!-- Existing scrolled-mode rendering: all pages stacked -->
+				{#each Array(totalPages) as _, i}
+					<canvas data-page={i + 1} bind:this={canvasRefs[i + 1]}></canvas>
+				{/each}
+			{/if}
+		</div>
+	{/snippet}
+</PaginatedViewport>
+```
+
+(Adapt to the actual canvas-rendering pattern in this file — canvas refs, render queue, etc.)
+
+- [ ] **Step 3: Add prev/next page navigation**
+
+```ts
+function goPrevPage() {
+	const step = resolveSpread(settings.spread, window.innerWidth) === 'dual' ? 2 : 1;
+	currentPage = Math.max(1, currentPage - step);
+}
+function goNextPage() {
+	const step = resolveSpread(settings.spread, window.innerWidth) === 'dual' ? 2 : 1;
+	currentPage = Math.min(totalPages, currentPage + step);
+}
+```
+
+- [ ] **Step 4: Persist current page to play_sessions**
+
+Existing scrolled-mode save loop already writes `currentPage` to `play_sessions.position`. In paginated mode, the same write fires whenever `currentPage` changes — wrap the existing save call in an `$effect` keyed off `currentPage` if it isn't already.
+
+- [ ] **Step 5: Render the shared settings panel in the existing drawer**
+
+Inside the PDF reader's right-side settings drawer, add:
+
+```svelte
+<ReaderSettingsPanel bind:settings variant="pdf" />
+```
+
+Remove the old single/dual spread toggle (now owned by `settings.spread`).
+
+- [ ] **Step 6: Typecheck**
+
+```bash
+pnpm check
+```
+Expected: 0 errors.
+
+- [ ] **Step 7: Manual smoke**
+
+Open a PDF in dev. Toggle Flow → Paginated, verify only current page(s) render. Click left/right tap zones. Swipe on a touch device or DevTools touch emulation. Toggle Spread → Single/Dual/Auto and verify rendering matches.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/lib/components/books/PdfReader.svelte
+git commit -m "feat(reader): add paginated mode to PDF reader (#61)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Cleanup KeyboardShortcuts (delete or generalize)
+
+**Files:**
+- Modify or delete: `src/lib/components/books/KeyboardShortcuts.svelte`
+
+The keyboard half of `useReaderInputs` now centralizes shortcuts. Check whether `KeyboardShortcuts.svelte` is still doing useful work (it may render a help overlay listing shortcuts — keep that part) or whether it's purely a listener (delete and remove its imports).
+
+- [ ] **Step 1: Inspect**
+
+```bash
+cat src/lib/components/books/KeyboardShortcuts.svelte
+grep -rn 'KeyboardShortcuts' src/lib/components/books/
+```
+
+- [ ] **Step 2: Decide**
+
+- If it's purely listener wiring → delete the file, remove imports/usages from BookReader, rely on `useReaderInputs.attachKeyboard()`.
+- If it renders a help overlay → keep the overlay markup, delete the listener half, remove duplicate handlers.
+
+- [ ] **Step 3: Typecheck**
+
+```bash
+pnpm check
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/components/books/
+git commit -m "refactor(reader): consolidate keyboard handling into useReaderInputs (#61)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+(Skip this commit if no changes were needed.)
+
+---
+
+## Task 8: Run full test suite + dev-build verification
+
+**Files:** none (verification step)
+
+- [ ] **Step 1: Vitest full run**
+
+```bash
+pnpm vitest run
+```
+Expected: all passing. Investigate any failures before proceeding.
+
+- [ ] **Step 2: Typecheck full**
+
+```bash
+pnpm check
+```
+Expected: 0 errors.
+
+- [ ] **Step 3: Production build**
+
+```bash
+pnpm build
+```
+Expected: build succeeds.
+
+- [ ] **Step 4: Smoke run server build locally**
+
+```bash
+PORT=8585 NEXUS_ENCRYPTION_KEY=$(openssl rand -hex 32) node build/index.js &
+SERVER_PID=$!
+sleep 5
+curl -sf http://localhost:8585/api/health && echo OK
+kill $SERVER_PID
+```
+
+Expected: `OK`. If startup fails, fix before deploy.
+
+- [ ] **Step 5: Commit any fixes from build verification**
+
+```bash
+git status
+# If any changes from build/smoke fixes:
+git add <files>
+git commit -m "fix(reader): build verification fixes (#61)"
+```
+
+---
+
+## Task 9: Deploy :dev image to jellyfin host
+
+**Files:** none (deployment step)
+
+The jellyfin host (10.10.10.15) currently runs the `ghcr.io/petalcat/nexus:dev` image built earlier from main. Replace it with a fresh image built from this branch.
+
+- [ ] **Step 1: Rsync source to server**
+
+```bash
+rsync -a --delete \
+  --exclude=node_modules --exclude=.svelte-kit --exclude=build \
+  --exclude=.git --exclude=.worktrees --exclude='.claude/worktrees' \
+  --exclude='*.db' --exclude='*.db-wal' --exclude='*.db-shm' \
+  --exclude=test-results --exclude=playwright-report \
+  --exclude=data --exclude=stream-proxy/target \
+  /Users/parker/Developer/Nexus/.worktrees/reader-paginated/ \
+  jellyfin@10.10.10.15:/home/jellyfin/docker/nexus-dev/
+```
+
+- [ ] **Step 2: Build image on server**
+
+```bash
+ssh jellyfin@10.10.10.15 "cd /home/jellyfin/docker/nexus-dev && docker build -t ghcr.io/petalcat/nexus:dev ."
+```
+
+- [ ] **Step 3: Recreate container**
+
+```bash
+ssh jellyfin@10.10.10.15 "cd /home/jellyfin/docker/nexus && docker compose up -d"
+```
+
+- [ ] **Step 4: Verify health + book load**
+
+```bash
+ssh jellyfin@10.10.10.15 "until curl -sf http://localhost:8585/api/health >/dev/null; do sleep 2; done && echo READY && docker logs nexus-nexus-1 --tail 20"
+```
+
+Expected: `READY` and log shows server listening.
+
+Then ask the user to test `/books/read/<id>` in the browser — verify EPUB loads in paginated mode, settings drawer shows new controls, prev/next works via tap/swipe/keyboard, Flow → Scrolled toggle works.
+
+- [ ] **Step 5: Final user-test sign-off**
+
+After user confirms it works, the next session will:
+- Commit any user-reported polish fixes
+- Open PR `feature/reader-paginated-mode → main`
+- After PR merge, GH Actions builds `ghcr.io/petalcat/nexus:latest`
+- Revert `/home/jellyfin/docker/nexus/docker-compose.yml` to `:latest` and `docker compose pull && up -d`
+
+---
+
+## Out of Scope (per spec)
+
+- Page curl animation
+- Per-zone tap action remapping
+- Two-up cover handling (first page solo)
+- Per-book settings overrides

--- a/docs/superpowers/specs/2026-04-19-reader-paginated-mode-design.md
+++ b/docs/superpowers/specs/2026-04-19-reader-paginated-mode-design.md
@@ -100,9 +100,11 @@ All three driven by the single `pageAnimation` setting; no per-format implementa
 
 ## Persistence
 
-Extend `userReaderPrefs` (already used by EPUB reader for theme/font/etc.) to include the new fields. Migrate existing rows: any row with the old `flow` field carries through; missing fields fall back to defaults at read time.
+Reader settings are persisted **client-side** in `localStorage` under the key `nexus-reader-settings`. The EPUB reader already uses this key for theme/font/etc. The PDF reader currently has no persistence; it will adopt the same key and shape.
 
-No schema migration needed for SQLite — the existing column is JSON; we extend the shape and tolerate missing keys.
+Storage shape extends the existing JSON object with the new fields. Reads tolerate missing keys (fall back to defaults), so existing users keep their theme/font/etc. without a migration. Writes always emit the full shape.
+
+A single helper module (`src/lib/components/books/reader-settings.ts`) owns the schema, defaults, load, and persist functions. Both readers consume it — no inline `localStorage.getItem('nexus-reader-settings')` reads elsewhere.
 
 ## Format-Default Bug Fix
 

--- a/docs/superpowers/specs/2026-04-19-reader-paginated-mode-design.md
+++ b/docs/superpowers/specs/2026-04-19-reader-paginated-mode-design.md
@@ -1,0 +1,138 @@
+---
+Status: in-flight
+Closes: #61
+---
+
+# Reader Paginated Mode — Design
+
+## Goal
+
+Bring the PDF reader to feature parity with the EPUB reader's paginated/scrolled flow modes, and unify the reader settings surface across both. The result: one familiar control panel that works on phone, tablet, and desktop, with the page-turn experience that physical-book readers expect.
+
+Also: a small bug fix so the EPUB reader doesn't load for books that have no EPUB format.
+
+## Background
+
+`BookReader.svelte` (foliate-js, EPUB) already supports `flow: paginated | scrolled` via a settings drawer toggle. `PdfReader.svelte` (PDF.js, our wrapper) is scroll-only with a `single | dual` spread mode. There is no shared settings model — each reader carries its own state and persistence.
+
+Today, opening a book with no EPUB format still routes to the EPUB reader because `+page.server.ts` defaults `format = 'epub'` regardless of what's actually available. This produces a broken reader for PDF-only books.
+
+## Requirements
+
+1. PDF reader gains `paginated` flow mode.
+2. EPUB reader gains the missing controls (spread, animation, per-input toggles, direction).
+3. Both readers share one settings model and one settings UI pattern.
+4. Settings persist per-user (extending the existing `userReaderPrefs` storage).
+5. Touch-friendly on phones, comfortable on tablets, fast on desktop.
+6. Bug fix: pick a sensible default format when EPUB is unavailable.
+
+## Settings Model
+
+A shared `ReaderSettings` shape, persisted per user:
+
+```ts
+interface ReaderSettings {
+  flow: 'paginated' | 'scrolled';        // default: 'paginated'
+  spread: 'auto' | 'single' | 'dual';    // default: 'auto'
+  pageAnimation: 'slide' | 'fade' | 'none'; // default: 'slide'
+  inputs: {
+    tapZones: boolean;  // default: true
+    swipe: boolean;     // default: true
+    keyboard: boolean;  // default: true
+  };
+  direction: 'ltr' | 'rtl';              // default: 'ltr'
+}
+```
+
+`spread: 'auto'` resolves at runtime: phones and portrait tablets → single, landscape tablets and desktop → dual. Resolution uses a CSS media query observed via a `$state` rune so it stays reactive when the device rotates.
+
+## Components
+
+### `PaginatedViewport.svelte` (new)
+
+A generic wrapper that owns flow, spread, animation, and input handling. PDF and EPUB readers each render their format-specific content as the viewport's slot child. The viewport's job is to translate user inputs (tap, swipe, key) and the active settings into "advance N pages" / "go back N pages" calls that the child handles.
+
+Why a wrapper rather than duplicating logic in each reader: input handling, gesture thresholds, animation state, and accessibility wiring are not format-specific. Splitting them out keeps each reader focused on rendering its own content.
+
+### `useReaderInputs.svelte.ts` (new)
+
+A small rune that wires touch (swipe), pointer (tap zones), and keyboard handlers. Caller passes `{ onPrev, onNext, onToggleUI, settings }` and gets back the appropriate event listeners as derived attachments. Centralizing this avoids three near-identical implementations.
+
+Tap zones: invisible overlays at left-third / middle / right-third. Tap-zone hit detection uses pointer events; debounced 200ms to prevent double-fire on touch-then-click.
+
+Swipe threshold: 50px minimum horizontal travel, must exceed vertical travel by 2x (avoids fighting vertical scroll in scrolled mode).
+
+Keyboard: ←/→ and PageUp/PageDown for prev/next, Space for next, Esc to close drawers. Already wired for EPUB; this consolidates.
+
+`direction: 'rtl'` flips the prev/next mapping for tap zones, swipe, and keyboard.
+
+### `KeyboardShortcuts.svelte`
+
+Extend the existing component to be format-agnostic; PDF reader picks it up.
+
+### `PdfReader.svelte` (modify)
+
+- Wrap rendered pages in `PaginatedViewport`.
+- In paginated mode: render only the current page (or current pair if `spread = dual`) at fit-to-viewport sizing, no scroll. Advance/back updates the current page index.
+- Existing `spreadMode` state becomes the `spread` setting; `auto` resolves at render time.
+- Page index continues to flow through `play_sessions.position` (already does for scrolled mode).
+
+### `BookReader.svelte` (modify)
+
+- Pull existing `flow` state out into the shared settings model.
+- Add the spread/animation/input/direction controls to its settings drawer.
+- Pass everything to `PaginatedViewport`.
+- foliate-js's `renderer.setAttribute('flow', ...)` continues to drive the underlying paginated layout; the wrapper just owns the chrome and inputs.
+
+### Settings UI
+
+Both readers' right-side drawers render the same `<ReaderSettingsPanel>` component. Single source of truth for layout and copy.
+
+## Animation
+
+Implemented via CSS on the viewport's page container:
+
+- `slide` (default): `transform: translateX(±100%)` with `transition: transform 220ms ease-out`. Two-buffer approach (current + incoming) so slide direction matches navigation direction.
+- `fade`: `opacity 0 → 1` over 150ms.
+- `none`: no transition.
+
+All three driven by the single `pageAnimation` setting; no per-format implementations.
+
+## Persistence
+
+Extend `userReaderPrefs` (already used by EPUB reader for theme/font/etc.) to include the new fields. Migrate existing rows: any row with the old `flow` field carries through; missing fields fall back to defaults at read time.
+
+No schema migration needed for SQLite — the existing column is JSON; we extend the shape and tolerate missing keys.
+
+## Format-Default Bug Fix
+
+In `src/routes/books/read/[id]/+page.server.ts`, change the format-resolution logic:
+
+```ts
+const requestedFormat = (url.searchParams.get('format') ?? 'epub').toLowerCase();
+const fallback = availableFormats[0] ?? 'epub';
+const format = availableFormats.includes(requestedFormat) ? requestedFormat : fallback;
+```
+
+If the requested format isn't available, fall back to the first available format rather than always to `'epub'`. For a PDF-only book, this routes to the PDF reader cleanly. If `availableFormats` is empty (no formats reported), the existing 404 from `getItem` returning null still fires upstream of this code.
+
+## Out of Scope
+
+- Page curl animation (skeuomorphic page-turn): expensive to make non-cringe, easy to skip.
+- Per-zone tap action remapping (custom action mapping per zone): YAGNI.
+- Two-up cover handling (first page solo, then pairs in dual mode): can add later if it bugs anyone.
+- Per-book settings overrides (settings are global per user, not per book).
+
+## Testing
+
+- Vitest: `useReaderInputs` rune — tap zone hit detection, swipe threshold, RTL direction flip, keyboard mapping.
+- Vitest: `PaginatedViewport` — flow switching, spread auto-resolution at different viewport widths, animation class application.
+- Manual: `pnpm dev`, exercise both readers across desktop, an iPad-sized viewport, and a phone-sized viewport. Verify tap zones, swipe, keyboard. Verify `:dev` build behavior on jellyfin host with TKAMB.
+
+## Migration / Rollout
+
+Single PR. No DB migration. No feature flag — the new settings panel replaces the existing one in both readers atomically. Old `userReaderPrefs` rows continue to work; missing fields hit defaults.
+
+## Open Questions
+
+None at design time. Implementation plan will surface anything that needs a follow-up.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,64 +107,9 @@ importers:
         version: 7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)
       vitest:
         specifier: ^4.1.2
-        version: 4.1.2(@types/node@25.3.3)(happy-dom@20.9.0)(jsdom@29.0.2)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1))
+        version: 4.1.2(@types/node@25.3.3)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1))
 
 packages:
-
-  '@asamuzakjp/css-color@5.1.11':
-    resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
-
-  '@asamuzakjp/dom-selector@7.1.1':
-    resolution: {integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
-
-  '@asamuzakjp/generational-cache@1.0.1':
-    resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
-
-  '@asamuzakjp/nwsapi@2.3.9':
-    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
-
-  '@bramus/specificity@2.4.2':
-    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
-    hasBin: true
-
-  '@csstools/color-helpers@6.0.2':
-    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
-    engines: {node: '>=20.19.0'}
-
-  '@csstools/css-calc@3.2.0':
-    resolution: {integrity: sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==}
-    engines: {node: '>=20.19.0'}
-    peerDependencies:
-      '@csstools/css-parser-algorithms': ^4.0.0
-      '@csstools/css-tokenizer': ^4.0.0
-
-  '@csstools/css-color-parser@4.1.0':
-    resolution: {integrity: sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==}
-    engines: {node: '>=20.19.0'}
-    peerDependencies:
-      '@csstools/css-parser-algorithms': ^4.0.0
-      '@csstools/css-tokenizer': ^4.0.0
-
-  '@csstools/css-parser-algorithms@4.0.0':
-    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
-    engines: {node: '>=20.19.0'}
-    peerDependencies:
-      '@csstools/css-tokenizer': ^4.0.0
-
-  '@csstools/css-syntax-patches-for-csstree@1.1.3':
-    resolution: {integrity: sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==}
-    peerDependencies:
-      css-tree: ^3.2.1
-    peerDependenciesMeta:
-      css-tree:
-        optional: true
-
-  '@csstools/css-tokenizer@4.0.0':
-    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
-    engines: {node: '>=20.19.0'}
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
@@ -620,15 +565,6 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
-
-  '@exodus/bytes@1.15.0':
-    resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
-    peerDependencies:
-      '@noble/hashes': ^1.8.0 || ^2.0.0
-    peerDependenciesMeta:
-      '@noble/hashes':
-        optional: true
 
   '@fontsource-variable/dm-sans@5.2.8':
     resolution: {integrity: sha512-AxkvMTvNWgfrmlyjiV05vlHYJa+nRQCf1EfvIrQAPBpFJW0O9VTz7oAFr9S3lvbWdmnFoBk7yFqQL86u64nl2g==}
@@ -1117,9 +1053,6 @@ packages:
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
-  '@types/whatwg-mimetype@3.0.2':
-    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
-
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
@@ -1184,9 +1117,6 @@ packages:
   better-sqlite3@11.10.0:
     resolution: {integrity: sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==}
 
-  bidi-js@1.0.3:
-    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
-
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
@@ -1231,16 +1161,8 @@ packages:
     resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
     engines: {node: '>= 0.6'}
 
-  css-tree@3.2.1:
-    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
-    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
-
   dashjs@5.1.1:
     resolution: {integrity: sha512-BzNXlUgzEjhuZ5M5hlSp1qIyQHZ7NpXAR0loP9DAAFVZj/ntL1DHeZ7qp/L3bvI4rq50X5indkAZQ3zEHWJoCA==}
-
-  data-urls@7.0.0:
-    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1250,9 +1172,6 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
-
-  decimal.js@10.6.0:
-    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
@@ -1376,14 +1295,6 @@ packages:
     resolution: {integrity: sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==}
     engines: {node: '>=10.13.0'}
 
-  entities@6.0.1:
-    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
-    engines: {node: '>=0.12'}
-
-  entities@7.0.1:
-    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
-    engines: {node: '>=0.12'}
-
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
@@ -1474,20 +1385,12 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
-  happy-dom@20.9.0:
-    resolution: {integrity: sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==}
-    engines: {node: '>=20.0.0'}
-
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
   hls.js@1.6.15:
     resolution: {integrity: sha512-E3a5VwgXimGHwpRGV+WxRTKeSp2DW5DI5MWv34ulL3t5UNmyJWCQ1KmLEHbYzcfThfXG8amBL+fCYPneGHC4VA==}
-
-  html-encoding-sniffer@6.0.0:
-    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   html-entities@2.6.0:
     resolution: {integrity: sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==}
@@ -1523,9 +1426,6 @@ packages:
   is-module@1.0.0:
     resolution: {integrity: sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==}
 
-  is-potential-custom-element-name@1.0.1:
-    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
-
   is-reference@1.2.1:
     resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
 
@@ -1535,15 +1435,6 @@ packages:
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
-
-  jsdom@29.0.2:
-    resolution: {integrity: sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
-    peerDependencies:
-      canvas: ^3.0.0
-    peerDependenciesMeta:
-      canvas:
-        optional: true
 
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
@@ -1640,9 +1531,6 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
-  mdn-data@2.27.1:
-    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
-
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
@@ -1684,9 +1572,6 @@ packages:
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
-
-  parse5@8.0.0:
-    resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
 
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
@@ -1807,10 +1692,6 @@ packages:
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
-  punycode@2.3.1:
-    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
-    engines: {node: '>=6'}
-
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
@@ -1822,10 +1703,6 @@ packages:
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
-
-  require-from-string@2.0.2:
-    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
-    engines: {node: '>=0.10.0'}
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
@@ -1849,10 +1726,6 @@ packages:
 
   sax@1.2.1:
     resolution: {integrity: sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==}
-
-  saxes@6.0.0:
-    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
-    engines: {node: '>=v12.22.7'}
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
@@ -1918,9 +1791,6 @@ packages:
     resolution: {integrity: sha512-lP5DGF3oDDI9fhHcSpaBiJEkFLuS16h92DhM1L5K1lFm0WjOmUh1i2sNkBBk8rkxJRpob0dBE75jRfUzGZUOGA==}
     engines: {node: '>=18'}
 
-  symbol-tree@3.2.4:
-    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
-
   tailwindcss@4.2.1:
     resolution: {integrity: sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==}
 
@@ -1950,24 +1820,9 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
-  tldts-core@7.0.28:
-    resolution: {integrity: sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==}
-
-  tldts@7.0.28:
-    resolution: {integrity: sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==}
-    hasBin: true
-
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
-
-  tough-cookie@6.0.1:
-    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
-    engines: {node: '>=16'}
-
-  tr46@6.0.0:
-    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
-    engines: {node: '>=20'}
 
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
@@ -1983,10 +1838,6 @@ packages:
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
-
-  undici@7.25.0:
-    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
-    engines: {node: '>=20.18.1'}
 
   undici@8.1.0:
     resolution: {integrity: sha512-E9MkTS4xXLnRPYqxH2e6Hr2/49e7WFDKczKcCaFH4VaZs2iNvHMqeIkyUAD9vM8kujy9TjVrRlQ5KkdEJxB2pw==}
@@ -2078,26 +1929,6 @@ packages:
       jsdom:
         optional: true
 
-  w3c-xmlserializer@5.0.0:
-    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
-    engines: {node: '>=18'}
-
-  webidl-conversions@8.0.1:
-    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
-    engines: {node: '>=20'}
-
-  whatwg-mimetype@3.0.0:
-    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
-    engines: {node: '>=12'}
-
-  whatwg-mimetype@5.0.0:
-    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
-    engines: {node: '>=20'}
-
-  whatwg-url@16.0.1:
-    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
-
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
@@ -2118,13 +1949,6 @@ packages:
       utf-8-validate:
         optional: true
 
-  xml-name-validator@5.0.0:
-    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
-    engines: {node: '>=18'}
-
-  xmlchars@2.2.0:
-    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
-
   zimmerframe@1.1.4:
     resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
 
@@ -2132,65 +1956,6 @@ packages:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
 snapshots:
-
-  '@asamuzakjp/css-color@5.1.11':
-    dependencies:
-      '@asamuzakjp/generational-cache': 1.0.1
-      '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
-      '@csstools/css-color-parser': 4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
-      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
-      '@csstools/css-tokenizer': 4.0.0
-    optional: true
-
-  '@asamuzakjp/dom-selector@7.1.1':
-    dependencies:
-      '@asamuzakjp/generational-cache': 1.0.1
-      '@asamuzakjp/nwsapi': 2.3.9
-      bidi-js: 1.0.3
-      css-tree: 3.2.1
-      is-potential-custom-element-name: 1.0.1
-    optional: true
-
-  '@asamuzakjp/generational-cache@1.0.1':
-    optional: true
-
-  '@asamuzakjp/nwsapi@2.3.9':
-    optional: true
-
-  '@bramus/specificity@2.4.2':
-    dependencies:
-      css-tree: 3.2.1
-    optional: true
-
-  '@csstools/color-helpers@6.0.2':
-    optional: true
-
-  '@csstools/css-calc@3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
-    dependencies:
-      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
-      '@csstools/css-tokenizer': 4.0.0
-    optional: true
-
-  '@csstools/css-color-parser@4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
-    dependencies:
-      '@csstools/color-helpers': 6.0.2
-      '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
-      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
-      '@csstools/css-tokenizer': 4.0.0
-    optional: true
-
-  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
-    dependencies:
-      '@csstools/css-tokenizer': 4.0.0
-    optional: true
-
-  '@csstools/css-syntax-patches-for-csstree@1.1.3(css-tree@3.2.1)':
-    optionalDependencies:
-      css-tree: 3.2.1
-    optional: true
-
-  '@csstools/css-tokenizer@4.0.0':
-    optional: true
 
   '@drizzle-team/brocli@0.10.2': {}
 
@@ -2424,9 +2189,6 @@ snapshots:
     optional: true
 
   '@esbuild/win32-x64@0.27.3':
-    optional: true
-
-  '@exodus/bytes@1.15.0':
     optional: true
 
   '@fontsource-variable/dm-sans@5.2.8': {}
@@ -2805,9 +2567,6 @@ snapshots:
 
   '@types/trusted-types@2.0.7': {}
 
-  '@types/whatwg-mimetype@3.0.2':
-    optional: true
-
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 25.3.3
@@ -2881,11 +2640,6 @@ snapshots:
       bindings: 1.5.0
       prebuild-install: 7.1.3
 
-  bidi-js@1.0.3:
-    dependencies:
-      require-from-string: 2.0.2
-    optional: true
-
   bindings@1.5.0:
     dependencies:
       file-uri-to-path: 1.0.0
@@ -2925,12 +2679,6 @@ snapshots:
 
   cookie@0.6.0: {}
 
-  css-tree@3.2.1:
-    dependencies:
-      mdn-data: 2.27.1
-      source-map-js: 1.2.1
-    optional: true
-
   dashjs@5.1.1(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1):
     dependencies:
       '@svta/cml-608': 1.0.1
@@ -2954,20 +2702,9 @@ snapshots:
       - '@svta/cml-structured-field-values'
       - '@svta/cml-utils'
 
-  data-urls@7.0.0:
-    dependencies:
-      whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1
-    transitivePeerDependencies:
-      - '@noble/hashes'
-    optional: true
-
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
-
-  decimal.js@10.6.0:
-    optional: true
 
   decompress-response@6.0.0:
     dependencies:
@@ -3003,12 +2740,6 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.0
-
-  entities@6.0.1:
-    optional: true
-
-  entities@7.0.1:
-    optional: true
 
   es-module-lexer@2.0.0: {}
 
@@ -3154,31 +2885,11 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  happy-dom@20.9.0:
-    dependencies:
-      '@types/node': 25.3.3
-      '@types/whatwg-mimetype': 3.0.2
-      '@types/ws': 8.18.1
-      entities: 7.0.1
-      whatwg-mimetype: 3.0.0
-      ws: 8.19.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-    optional: true
-
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
 
   hls.js@1.6.15: {}
-
-  html-encoding-sniffer@6.0.0:
-    dependencies:
-      '@exodus/bytes': 1.15.0
-    transitivePeerDependencies:
-      - '@noble/hashes'
-    optional: true
 
   html-entities@2.6.0: {}
 
@@ -3209,9 +2920,6 @@ snapshots:
 
   is-module@1.0.0: {}
 
-  is-potential-custom-element-name@1.0.1:
-    optional: true
-
   is-reference@1.2.1:
     dependencies:
       '@types/estree': 1.0.8
@@ -3221,33 +2929,6 @@ snapshots:
       '@types/estree': 1.0.8
 
   jiti@2.6.1: {}
-
-  jsdom@29.0.2:
-    dependencies:
-      '@asamuzakjp/css-color': 5.1.11
-      '@asamuzakjp/dom-selector': 7.1.1
-      '@bramus/specificity': 2.4.2
-      '@csstools/css-syntax-patches-for-csstree': 1.1.3(css-tree@3.2.1)
-      '@exodus/bytes': 1.15.0
-      css-tree: 3.2.1
-      data-urls: 7.0.0
-      decimal.js: 10.6.0
-      html-encoding-sniffer: 6.0.0
-      is-potential-custom-element-name: 1.0.1
-      lru-cache: 11.3.5
-      parse5: 8.0.0
-      saxes: 6.0.0
-      symbol-tree: 3.2.4
-      tough-cookie: 6.0.1
-      undici: 7.25.0
-      w3c-xmlserializer: 5.0.0
-      webidl-conversions: 8.0.1
-      whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1
-      xml-name-validator: 5.0.0
-    transitivePeerDependencies:
-      - '@noble/hashes'
-    optional: true
 
   kleur@4.1.5: {}
 
@@ -3320,9 +3001,6 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  mdn-data@2.27.1:
-    optional: true
-
   mimic-response@3.1.0: {}
 
   minimist@1.2.8: {}
@@ -3351,11 +3029,6 @@ snapshots:
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
-
-  parse5@8.0.0:
-    dependencies:
-      entities: 6.0.1
-    optional: true
 
   path-browserify@1.0.1: {}
 
@@ -3421,9 +3094,6 @@ snapshots:
       end-of-stream: 1.4.5
       once: 1.4.0
 
-  punycode@2.3.1:
-    optional: true
-
   rc@1.2.8:
     dependencies:
       deep-extend: 0.6.0
@@ -3438,9 +3108,6 @@ snapshots:
       util-deprecate: 1.0.2
 
   readdirp@4.1.2: {}
-
-  require-from-string@2.0.2:
-    optional: true
 
   resolve-pkg-maps@1.0.0: {}
 
@@ -3488,11 +3155,6 @@ snapshots:
   safe-buffer@5.2.1: {}
 
   sax@1.2.1: {}
-
-  saxes@6.0.0:
-    dependencies:
-      xmlchars: 2.2.0
-    optional: true
 
   semver@7.7.4: {}
 
@@ -3568,9 +3230,6 @@ snapshots:
       magic-string: 0.30.21
       zimmerframe: 1.1.4
 
-  symbol-tree@3.2.4:
-    optional: true
-
   tailwindcss@4.2.1: {}
 
   tapable@2.3.0: {}
@@ -3601,25 +3260,7 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
-  tldts-core@7.0.28:
-    optional: true
-
-  tldts@7.0.28:
-    dependencies:
-      tldts-core: 7.0.28
-    optional: true
-
   totalist@3.0.1: {}
-
-  tough-cookie@6.0.1:
-    dependencies:
-      tldts: 7.0.28
-    optional: true
-
-  tr46@6.0.0:
-    dependencies:
-      punycode: 2.3.1
-    optional: true
 
   tunnel-agent@0.6.0:
     dependencies:
@@ -3630,9 +3271,6 @@ snapshots:
   ua-parser-js@1.0.41: {}
 
   undici-types@7.18.2: {}
-
-  undici@7.25.0:
-    optional: true
 
   undici@8.1.0: {}
 
@@ -3656,7 +3294,7 @@ snapshots:
     optionalDependencies:
       vite: 7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)
 
-  vitest@4.1.2(@types/node@25.3.3)(happy-dom@20.9.0)(jsdom@29.0.2)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)):
+  vitest@4.1.2(@types/node@25.3.3)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)):
     dependencies:
       '@vitest/expect': 4.1.2
       '@vitest/mocker': 4.1.2(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1))
@@ -3680,33 +3318,8 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.3.3
-      happy-dom: 20.9.0
-      jsdom: 29.0.2
     transitivePeerDependencies:
       - msw
-
-  w3c-xmlserializer@5.0.0:
-    dependencies:
-      xml-name-validator: 5.0.0
-    optional: true
-
-  webidl-conversions@8.0.1:
-    optional: true
-
-  whatwg-mimetype@3.0.0:
-    optional: true
-
-  whatwg-mimetype@5.0.0:
-    optional: true
-
-  whatwg-url@16.0.1:
-    dependencies:
-      '@exodus/bytes': 1.15.0
-      tr46: 6.0.0
-      webidl-conversions: 8.0.1
-    transitivePeerDependencies:
-      - '@noble/hashes'
-    optional: true
 
   why-is-node-running@2.3.0:
     dependencies:
@@ -3716,12 +3329,6 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.19.0: {}
-
-  xml-name-validator@5.0.0:
-    optional: true
-
-  xmlchars@2.2.0:
-    optional: true
 
   zimmerframe@1.1.4: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,9 +107,64 @@ importers:
         version: 7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)
       vitest:
         specifier: ^4.1.2
-        version: 4.1.2(@types/node@25.3.3)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1))
+        version: 4.1.2(@types/node@25.3.3)(happy-dom@20.9.0)(jsdom@29.0.2)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1))
 
 packages:
+
+  '@asamuzakjp/css-color@5.1.11':
+    resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    resolution: {integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/generational-cache@1.0.1':
+    resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.2.0':
+    resolution: {integrity: sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.0':
+    resolution: {integrity: sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.3':
+    resolution: {integrity: sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
@@ -565,6 +620,15 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@exodus/bytes@1.15.0':
+    resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@fontsource-variable/dm-sans@5.2.8':
     resolution: {integrity: sha512-AxkvMTvNWgfrmlyjiV05vlHYJa+nRQCf1EfvIrQAPBpFJW0O9VTz7oAFr9S3lvbWdmnFoBk7yFqQL86u64nl2g==}
@@ -1053,6 +1117,9 @@ packages:
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
@@ -1117,6 +1184,9 @@ packages:
   better-sqlite3@11.10.0:
     resolution: {integrity: sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==}
 
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
@@ -1161,8 +1231,16 @@ packages:
     resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
     engines: {node: '>= 0.6'}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   dashjs@5.1.1:
     resolution: {integrity: sha512-BzNXlUgzEjhuZ5M5hlSp1qIyQHZ7NpXAR0loP9DAAFVZj/ntL1DHeZ7qp/L3bvI4rq50X5indkAZQ3zEHWJoCA==}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1172,6 +1250,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
@@ -1295,6 +1376,14 @@ packages:
     resolution: {integrity: sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==}
     engines: {node: '>=10.13.0'}
 
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
@@ -1385,12 +1474,20 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  happy-dom@20.9.0:
+    resolution: {integrity: sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==}
+    engines: {node: '>=20.0.0'}
+
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
   hls.js@1.6.15:
     resolution: {integrity: sha512-E3a5VwgXimGHwpRGV+WxRTKeSp2DW5DI5MWv34ulL3t5UNmyJWCQ1KmLEHbYzcfThfXG8amBL+fCYPneGHC4VA==}
+
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   html-entities@2.6.0:
     resolution: {integrity: sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==}
@@ -1426,6 +1523,9 @@ packages:
   is-module@1.0.0:
     resolution: {integrity: sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-reference@1.2.1:
     resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
 
@@ -1435,6 +1535,15 @@ packages:
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
+
+  jsdom@29.0.2:
+    resolution: {integrity: sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
@@ -1531,6 +1640,9 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
@@ -1572,6 +1684,9 @@ packages:
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  parse5@8.0.0:
+    resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
 
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
@@ -1692,6 +1807,10 @@ packages:
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
@@ -1703,6 +1822,10 @@ packages:
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
@@ -1726,6 +1849,10 @@ packages:
 
   sax@1.2.1:
     resolution: {integrity: sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
@@ -1791,6 +1918,9 @@ packages:
     resolution: {integrity: sha512-lP5DGF3oDDI9fhHcSpaBiJEkFLuS16h92DhM1L5K1lFm0WjOmUh1i2sNkBBk8rkxJRpob0dBE75jRfUzGZUOGA==}
     engines: {node: '>=18'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tailwindcss@4.2.1:
     resolution: {integrity: sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==}
 
@@ -1820,9 +1950,24 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.0.28:
+    resolution: {integrity: sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==}
+
+  tldts@7.0.28:
+    resolution: {integrity: sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==}
+    hasBin: true
+
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
+
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
@@ -1838,6 +1983,10 @@ packages:
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+    engines: {node: '>=20.18.1'}
 
   undici@8.1.0:
     resolution: {integrity: sha512-E9MkTS4xXLnRPYqxH2e6Hr2/49e7WFDKczKcCaFH4VaZs2iNvHMqeIkyUAD9vM8kujy9TjVrRlQ5KkdEJxB2pw==}
@@ -1929,6 +2078,26 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
@@ -1949,6 +2118,13 @@ packages:
       utf-8-validate:
         optional: true
 
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   zimmerframe@1.1.4:
     resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
 
@@ -1956,6 +2132,65 @@ packages:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
 snapshots:
+
+  '@asamuzakjp/css-color@5.1.11':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+    optional: true
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+    optional: true
+
+  '@asamuzakjp/generational-cache@1.0.1':
+    optional: true
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    optional: true
+
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+    optional: true
+
+  '@csstools/color-helpers@6.0.2':
+    optional: true
+
+  '@csstools/css-calc@3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+    optional: true
+
+  '@csstools/css-color-parser@4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+    optional: true
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+    optional: true
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.3(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+    optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    optional: true
 
   '@drizzle-team/brocli@0.10.2': {}
 
@@ -2189,6 +2424,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-x64@0.27.3':
+    optional: true
+
+  '@exodus/bytes@1.15.0':
     optional: true
 
   '@fontsource-variable/dm-sans@5.2.8': {}
@@ -2567,6 +2805,9 @@ snapshots:
 
   '@types/trusted-types@2.0.7': {}
 
+  '@types/whatwg-mimetype@3.0.2':
+    optional: true
+
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 25.3.3
@@ -2640,6 +2881,11 @@ snapshots:
       bindings: 1.5.0
       prebuild-install: 7.1.3
 
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
+    optional: true
+
   bindings@1.5.0:
     dependencies:
       file-uri-to-path: 1.0.0
@@ -2679,6 +2925,12 @@ snapshots:
 
   cookie@0.6.0: {}
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+    optional: true
+
   dashjs@5.1.1(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1):
     dependencies:
       '@svta/cml-608': 1.0.1
@@ -2702,9 +2954,20 @@ snapshots:
       - '@svta/cml-structured-field-values'
       - '@svta/cml-utils'
 
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+    optional: true
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0:
+    optional: true
 
   decompress-response@6.0.0:
     dependencies:
@@ -2740,6 +3003,12 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.0
+
+  entities@6.0.1:
+    optional: true
+
+  entities@7.0.1:
+    optional: true
 
   es-module-lexer@2.0.0: {}
 
@@ -2885,11 +3154,31 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  happy-dom@20.9.0:
+    dependencies:
+      '@types/node': 25.3.3
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    optional: true
+
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
 
   hls.js@1.6.15: {}
+
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+    optional: true
 
   html-entities@2.6.0: {}
 
@@ -2920,6 +3209,9 @@ snapshots:
 
   is-module@1.0.0: {}
 
+  is-potential-custom-element-name@1.0.1:
+    optional: true
+
   is-reference@1.2.1:
     dependencies:
       '@types/estree': 1.0.8
@@ -2929,6 +3221,33 @@ snapshots:
       '@types/estree': 1.0.8
 
   jiti@2.6.1: {}
+
+  jsdom@29.0.2:
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.11
+      '@asamuzakjp/dom-selector': 7.1.1
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.3(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.0
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.3.5
+      parse5: 8.0.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.25.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+    optional: true
 
   kleur@4.1.5: {}
 
@@ -3001,6 +3320,9 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  mdn-data@2.27.1:
+    optional: true
+
   mimic-response@3.1.0: {}
 
   minimist@1.2.8: {}
@@ -3029,6 +3351,11 @@ snapshots:
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
+
+  parse5@8.0.0:
+    dependencies:
+      entities: 6.0.1
+    optional: true
 
   path-browserify@1.0.1: {}
 
@@ -3094,6 +3421,9 @@ snapshots:
       end-of-stream: 1.4.5
       once: 1.4.0
 
+  punycode@2.3.1:
+    optional: true
+
   rc@1.2.8:
     dependencies:
       deep-extend: 0.6.0
@@ -3108,6 +3438,9 @@ snapshots:
       util-deprecate: 1.0.2
 
   readdirp@4.1.2: {}
+
+  require-from-string@2.0.2:
+    optional: true
 
   resolve-pkg-maps@1.0.0: {}
 
@@ -3155,6 +3488,11 @@ snapshots:
   safe-buffer@5.2.1: {}
 
   sax@1.2.1: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+    optional: true
 
   semver@7.7.4: {}
 
@@ -3230,6 +3568,9 @@ snapshots:
       magic-string: 0.30.21
       zimmerframe: 1.1.4
 
+  symbol-tree@3.2.4:
+    optional: true
+
   tailwindcss@4.2.1: {}
 
   tapable@2.3.0: {}
@@ -3260,7 +3601,25 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
+  tldts-core@7.0.28:
+    optional: true
+
+  tldts@7.0.28:
+    dependencies:
+      tldts-core: 7.0.28
+    optional: true
+
   totalist@3.0.1: {}
+
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.0.28
+    optional: true
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
+    optional: true
 
   tunnel-agent@0.6.0:
     dependencies:
@@ -3271,6 +3630,9 @@ snapshots:
   ua-parser-js@1.0.41: {}
 
   undici-types@7.18.2: {}
+
+  undici@7.25.0:
+    optional: true
 
   undici@8.1.0: {}
 
@@ -3294,7 +3656,7 @@ snapshots:
     optionalDependencies:
       vite: 7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)
 
-  vitest@4.1.2(@types/node@25.3.3)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)):
+  vitest@4.1.2(@types/node@25.3.3)(happy-dom@20.9.0)(jsdom@29.0.2)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)):
     dependencies:
       '@vitest/expect': 4.1.2
       '@vitest/mocker': 4.1.2(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1))
@@ -3318,8 +3680,33 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.3.3
+      happy-dom: 20.9.0
+      jsdom: 29.0.2
     transitivePeerDependencies:
       - msw
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+    optional: true
+
+  webidl-conversions@8.0.1:
+    optional: true
+
+  whatwg-mimetype@3.0.0:
+    optional: true
+
+  whatwg-mimetype@5.0.0:
+    optional: true
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+    optional: true
 
   why-is-node-running@2.3.0:
     dependencies:
@@ -3329,6 +3716,12 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.19.0: {}
+
+  xml-name-validator@5.0.0:
+    optional: true
+
+  xmlchars@2.2.0:
+    optional: true
 
   zimmerframe@1.1.4: {}
 

--- a/src/lib/components/books/BookReader.svelte
+++ b/src/lib/components/books/BookReader.svelte
@@ -498,9 +498,8 @@
 	function handleKeydown(e: KeyboardEvent) {
 		if (showSearch && e.key !== 'Escape') return;
 		if (showNoteInput && e.key !== 'Escape') return;
+		// ArrowLeft/Right are owned by PaginatedViewport (gated by settings.inputs.keyboard).
 		switch (e.key) {
-			case 'ArrowLeft': e.preventDefault(); prevPage(); break;
-			case 'ArrowRight': e.preventDefault(); nextPage(); break;
 			case 'Escape':
 				e.preventDefault();
 				if (showAnnotationPopup) dismissAnnotationPopup();

--- a/src/lib/components/books/BookReader.svelte
+++ b/src/lib/components/books/BookReader.svelte
@@ -12,6 +12,9 @@
 	import ReaderProgressBar from './ReaderProgressBar.svelte';
 	import TimeEstimate from './TimeEstimate.svelte';
 	import KeyboardShortcuts from './KeyboardShortcuts.svelte';
+	import PaginatedViewport from './PaginatedViewport.svelte';
+	import ReaderSettingsPanel from './ReaderSettingsPanel.svelte';
+	import { loadReaderSettings, persistReaderSettings, DEFAULT_READER_SETTINGS, type ReaderSettings } from './reader-settings';
 
 	interface Props {
 		epubUrl: string;
@@ -104,36 +107,40 @@
 		{ label: 'Shortcuts', key: '?' }
 	];
 
-	// Reader settings (persisted in localStorage)
-	let readerTheme = $state<'dark' | 'light' | 'sepia' | 'oled'>('dark');
-	let fontFamily = $state<'serif' | 'sans' | 'mono' | 'display'>('serif');
-	let fontSize = $state(18);
-	let lineHeight = $state(1.6);
-	let margins = $state<'narrow' | 'medium' | 'wide'>('medium');
-	let textAlign = $state<'start' | 'justify'>('start');
-	let flow = $state<'paginated' | 'scrolled'>('paginated');
+	// Reader settings (persisted in localStorage via shared module)
+	let settings = $state<ReaderSettings>({ ...DEFAULT_READER_SETTINGS });
+
+	// Derived aliases — keeps existing template references working; all writes
+	// go back into `settings` so there is a single source of truth.
+	const readerTheme = $derived(settings.theme);
+	const fontFamily = $derived(settings.fontFamily);
+	const fontSize = $derived(settings.fontSize);
+	const lineHeight = $derived(settings.lineHeight);
+	const margins = $derived(settings.margins);
+	const textAlign = $derived(settings.textAlign);
+	const flow = $derived(settings.flow);
 
 	let hideTimer: ReturnType<typeof setTimeout> | null = null;
 
 	const anyPanelOpen = $derived(showToc || showSettings || showBookmarks || showSearch || showFormatMenu);
 
-	const themes: Record<string, { bg: string; text: string; link: string }> = {
+	const themes: Record<ReaderSettings['theme'], { bg: string; text: string; link: string }> = {
 		dark: { bg: '#181514', text: '#f0ebe3', link: '#d4a253' },
 		light: { bg: '#faf8f5', text: '#1a1a1a', link: '#b8862e' },
 		sepia: { bg: '#f4ecd8', text: '#5b4636', link: '#8b6914' },
-		oled: { bg: '#000000', text: '#b0b0b0', link: '#d4a253' }
+		night: { bg: '#000000', text: '#b0b0b0', link: '#d4a253' }
 	};
 
-	const fonts: Record<string, string> = {
+	const fonts: Record<ReaderSettings['fontFamily'], string> = {
 		serif: "Georgia, 'Times New Roman', serif",
 		sans: "system-ui, -apple-system, 'Segoe UI', sans-serif",
 		mono: "'JetBrains Mono', 'Fira Code', monospace",
-		display: "'Playfair Display', Georgia, serif"
+		dyslexic: "'OpenDyslexic', 'Playfair Display', Georgia, serif"
 	};
 
-	const marginValues: Record<string, string> = {
+	const marginValues: Record<ReaderSettings['margins'], string> = {
 		narrow: '2%',
-		medium: '6%',
+		normal: '6%',
 		wide: '12%'
 	};
 
@@ -144,30 +151,15 @@
 		pink: 'rgba(251, 113, 133, 0.3)'
 	};
 
-	// ── Settings persistence ──
-	function loadSettings() {
-		if (!browser) return;
-		try {
-			const saved = localStorage.getItem('nexus-reader-settings');
-			if (saved) {
-				const s = JSON.parse(saved);
-				if (s.theme && s.theme in themes) readerTheme = s.theme;
-				if (s.fontFamily && s.fontFamily in fonts) fontFamily = s.fontFamily;
-				if (s.fontSize) fontSize = s.fontSize;
-				if (s.lineHeight) lineHeight = s.lineHeight;
-				if (s.margins && s.margins in marginValues) margins = s.margins;
-				if (s.textAlign === 'start' || s.textAlign === 'justify') textAlign = s.textAlign;
-				if (s.flow) flow = s.flow;
-			}
-		} catch { /* ignore */ }
-	}
+	// ── Settings persistence (via shared module) ──
+	// Writes are persisted via $effect below; reads happen lazily in
+	// initFoliateReader so the reader hydrates with whatever's in localStorage.
 
-	function persistSettings() {
+	$effect(() => {
+		// Persist on every change. `persistReaderSettings` merges into stored state.
 		if (!browser) return;
-		localStorage.setItem('nexus-reader-settings', JSON.stringify({
-			theme: readerTheme, fontFamily, fontSize, lineHeight, margins, textAlign, flow
-		}));
-	}
+		persistReaderSettings(settings);
+	});
 
 	// ── Build CSS for foliate-js renderer ──
 	function getReaderCSS(): string {
@@ -218,7 +210,6 @@
 	function applyStyles() {
 		if (!view?.renderer?.setStyles) return;
 		view.renderer.setStyles(getReaderCSS());
-		persistSettings();
 	}
 
 	// ── Flatten TOC for display ──
@@ -528,7 +519,8 @@
 
 	// ── Svelte action for foliate-js lifecycle ──
 	function initFoliateReader(node: HTMLElement) {
-		loadSettings();
+		// Hydrate settings from localStorage before the view opens
+		settings = loadReaderSettings();
 
 		// Sync initial prop values
 		currentProgress = initialProgress;
@@ -684,12 +676,11 @@
 		if (view && ready) applyStyles();
 	});
 
-	// Handle flow change
+	// Handle flow + direction changes — drive the foliate renderer directly.
 	$effect(() => {
-		if (!view || !ready) return;
-		void flow;
-		view.renderer.setAttribute('flow', flow);
-		persistSettings();
+		if (!view?.renderer) return;
+		view.renderer.setAttribute('flow', settings.flow);
+		view.renderer.setAttribute('dir', settings.direction);
 	});
 
 	const progressPercent = $derived(Math.round(currentProgress * 100));
@@ -790,12 +781,22 @@
 	style="background-color: {themes[readerTheme].bg};"
 	onmousemove={handleReaderMouseMove}
 >
-	<!-- foliate-js container -->
-	<div
-		use:initFoliateReader
-		class="absolute overflow-hidden"
-		style="top: 0; bottom: 0; left: 0; right: 0;"
-	></div>
+	<!-- foliate-js container, wrapped by PaginatedViewport for shared input/animation behavior -->
+	<div class="absolute" style="top: 0; bottom: 0; left: 0; right: 0;">
+		<PaginatedViewport
+			{settings}
+			onPrev={() => view?.prev()}
+			onNext={() => view?.next()}
+			onToggleUI={() => { showSettings = !showSettings; }}
+		>
+			{#snippet children(_ctx: { effectiveSpread: 'single' | 'dual'; animationKey: number })}
+				<div
+					use:initFoliateReader
+					class="h-full w-full overflow-hidden"
+				></div>
+			{/snippet}
+		</PaginatedViewport>
+	</div>
 
 	<!-- Click zone overlay for navigation (only outside the iframe) -->
 	<button
@@ -909,10 +910,10 @@
 			<div class="mb-5">
 				<span class="settings-label">Theme</span>
 				<div class="grid grid-cols-4 gap-2">
-					{#each [{ key: 'light', label: 'Light', bg: '#faf8f5', ring: '#ccc' }, { key: 'sepia', label: 'Sepia', bg: '#f4ecd8', ring: '#c4a96a' }, { key: 'dark', label: 'Dark', bg: '#181514', ring: '#555' }, { key: 'oled', label: 'OLED', bg: '#000000', ring: '#333' }] as { key, label, bg, ring } (key)}
+					{#each [{ key: 'light', label: 'Light', bg: '#faf8f5', ring: '#ccc' }, { key: 'sepia', label: 'Sepia', bg: '#f4ecd8', ring: '#c4a96a' }, { key: 'dark', label: 'Dark', bg: '#181514', ring: '#555' }, { key: 'night', label: 'OLED', bg: '#000000', ring: '#333' }] as { key, label, bg, ring } (key)}
 						<button
 							class="flex flex-col items-center justify-center gap-1.5 rounded-lg border px-2 py-2.5 text-[10px] transition-all {readerTheme === key ? 'border-[var(--color-accent)] bg-[var(--color-accent)]/10 text-[var(--color-accent)]' : 'border-cream/[0.08] text-cream/40 hover:border-cream/20 hover:text-cream/60'}"
-							onclick={() => { readerTheme = key as typeof readerTheme; }}
+							onclick={() => { settings.theme = key as ReaderSettings['theme']; }}
 						>
 							<span
 								class="h-5 w-5 rounded-full border-2"
@@ -928,11 +929,11 @@
 			<div class="mb-5">
 				<span class="settings-label">Font</span>
 				<div class="grid grid-cols-4 gap-1.5">
-					{#each [{ key: 'serif', label: 'Serif', font: 'Georgia, serif' }, { key: 'sans', label: 'Sans', font: 'system-ui, sans-serif' }, { key: 'mono', label: 'Mono', font: "'JetBrains Mono', monospace" }, { key: 'display', label: 'Display', font: "'Playfair Display', Georgia, serif" }] as { key, label, font } (key)}
+					{#each [{ key: 'serif', label: 'Serif', font: 'Georgia, serif' }, { key: 'sans', label: 'Sans', font: 'system-ui, sans-serif' }, { key: 'mono', label: 'Mono', font: "'JetBrains Mono', monospace" }, { key: 'dyslexic', label: 'Display', font: "'Playfair Display', Georgia, serif" }] as { key, label, font } (key)}
 						<button
 							class="rounded-lg border px-2 py-2 text-xs transition-all {fontFamily === key ? 'border-[var(--color-accent)] bg-[var(--color-accent)]/10 text-[var(--color-accent)]' : 'border-cream/[0.08] text-cream/50 hover:border-cream/20 hover:text-cream/70'}"
 							style="font-family: {font};"
-							onclick={() => { fontFamily = key as typeof fontFamily; }}
+							onclick={() => { settings.fontFamily = key as ReaderSettings['fontFamily']; }}
 						>{label}</button>
 					{/each}
 				</div>
@@ -946,7 +947,7 @@
 				</label>
 				<div class="flex items-center gap-3">
 					<Type size={12} class="shrink-0 text-cream/30" />
-					<input id="reader-font-size" type="range" min="12" max="36" step="1" bind:value={fontSize} class="reader-range flex-1" />
+					<input id="reader-font-size" type="range" min="12" max="36" step="1" bind:value={settings.fontSize} class="reader-range flex-1" />
 					<Type size={20} class="shrink-0 text-cream/30" />
 				</div>
 			</div>
@@ -957,17 +958,17 @@
 					<span>Line Height</span>
 					<span class="normal-case tracking-normal text-cream/60">{lineHeight.toFixed(1)}</span>
 				</label>
-				<input id="reader-line-height" type="range" min="1.0" max="2.0" step="0.1" bind:value={lineHeight} class="reader-range w-full" />
+				<input id="reader-line-height" type="range" min="1.0" max="2.0" step="0.1" bind:value={settings.lineHeight} class="reader-range w-full" />
 			</div>
 
 			<!-- Margins -->
 			<div class="mb-5">
 				<span class="settings-label">Margins</span>
 				<div class="flex gap-2">
-					{#each [{ key: 'narrow', label: 'Narrow' }, { key: 'medium', label: 'Medium' }, { key: 'wide', label: 'Wide' }] as { key, label } (key)}
+					{#each [{ key: 'narrow', label: 'Narrow' }, { key: 'normal', label: 'Medium' }, { key: 'wide', label: 'Wide' }] as { key, label } (key)}
 						<button
 							class="flex-1 rounded-lg border px-3 py-2 text-xs transition-all {margins === key ? 'border-[var(--color-accent)] bg-[var(--color-accent)]/10 text-[var(--color-accent)]' : 'border-cream/[0.08] text-cream/50 hover:border-cream/20 hover:text-cream/70'}"
-							onclick={() => { margins = key as typeof margins; }}
+							onclick={() => { settings.margins = key as ReaderSettings['margins']; }}
 						>{label}</button>
 					{/each}
 				</div>
@@ -979,33 +980,21 @@
 				<div class="flex gap-2">
 					<button
 						class="flex flex-1 items-center justify-center gap-1.5 rounded-lg border px-3 py-2 text-xs transition-all {textAlign === 'start' ? 'border-[var(--color-accent)] bg-[var(--color-accent)]/10 text-[var(--color-accent)]' : 'border-cream/[0.08] text-cream/50 hover:border-cream/20 hover:text-cream/70'}"
-						onclick={() => { textAlign = 'start'; }}
+						onclick={() => { settings.textAlign = 'start'; }}
 					>
 						<AlignLeft size={13} strokeWidth={1.5} /> Left
 					</button>
 					<button
 						class="flex flex-1 items-center justify-center gap-1.5 rounded-lg border px-3 py-2 text-xs transition-all {textAlign === 'justify' ? 'border-[var(--color-accent)] bg-[var(--color-accent)]/10 text-[var(--color-accent)]' : 'border-cream/[0.08] text-cream/50 hover:border-cream/20 hover:text-cream/70'}"
-						onclick={() => { textAlign = 'justify'; }}
+						onclick={() => { settings.textAlign = 'justify'; }}
 					>
 						<AlignJustify size={13} strokeWidth={1.5} /> Justified
 					</button>
 				</div>
 			</div>
 
-			<!-- Reading Mode -->
-			<div>
-				<span class="settings-label">Reading Mode</span>
-				<div class="flex gap-2">
-					<button
-						class="flex-1 rounded-lg border px-3 py-2 text-xs transition-all {flow === 'paginated' ? 'border-[var(--color-accent)] bg-[var(--color-accent)]/10 text-[var(--color-accent)]' : 'border-cream/[0.08] text-cream/50 hover:border-cream/20 hover:text-cream/70'}"
-						onclick={() => { flow = 'paginated'; }}
-					>Paginated</button>
-					<button
-						class="flex-1 rounded-lg border px-3 py-2 text-xs transition-all {flow === 'scrolled' ? 'border-[var(--color-accent)] bg-[var(--color-accent)]/10 text-[var(--color-accent)]' : 'border-cream/[0.08] text-cream/50 hover:border-cream/20 hover:text-cream/70'}"
-						onclick={() => { flow = 'scrolled'; }}
-					>Scrolled</button>
-				</div>
-			</div>
+			<!-- Shared paginated / flow / spread / inputs / direction panel -->
+			<ReaderSettingsPanel bind:settings variant="epub" />
 		</div>
 	</div>
 {/if}

--- a/src/lib/components/books/BookReader.svelte
+++ b/src/lib/components/books/BookReader.svelte
@@ -128,19 +128,19 @@
 		dark: { bg: '#181514', text: '#f0ebe3', link: '#d4a253' },
 		light: { bg: '#faf8f5', text: '#1a1a1a', link: '#b8862e' },
 		sepia: { bg: '#f4ecd8', text: '#5b4636', link: '#8b6914' },
-		night: { bg: '#000000', text: '#b0b0b0', link: '#d4a253' }
+		oled: { bg: '#000000', text: '#b0b0b0', link: '#d4a253' }
 	};
 
 	const fonts: Record<ReaderSettings['fontFamily'], string> = {
 		serif: "Georgia, 'Times New Roman', serif",
 		sans: "system-ui, -apple-system, 'Segoe UI', sans-serif",
 		mono: "'JetBrains Mono', 'Fira Code', monospace",
-		dyslexic: "'OpenDyslexic', 'Playfair Display', Georgia, serif"
+		display: "'Playfair Display', Georgia, serif"
 	};
 
 	const marginValues: Record<ReaderSettings['margins'], string> = {
 		narrow: '2%',
-		normal: '6%',
+		medium: '6%',
 		wide: '12%'
 	};
 
@@ -910,7 +910,7 @@
 			<div class="mb-5">
 				<span class="settings-label">Theme</span>
 				<div class="grid grid-cols-4 gap-2">
-					{#each [{ key: 'light', label: 'Light', bg: '#faf8f5', ring: '#ccc' }, { key: 'sepia', label: 'Sepia', bg: '#f4ecd8', ring: '#c4a96a' }, { key: 'dark', label: 'Dark', bg: '#181514', ring: '#555' }, { key: 'night', label: 'OLED', bg: '#000000', ring: '#333' }] as { key, label, bg, ring } (key)}
+					{#each [{ key: 'light', label: 'Light', bg: '#faf8f5', ring: '#ccc' }, { key: 'sepia', label: 'Sepia', bg: '#f4ecd8', ring: '#c4a96a' }, { key: 'dark', label: 'Dark', bg: '#181514', ring: '#555' }, { key: 'oled', label: 'OLED', bg: '#000000', ring: '#333' }] as { key, label, bg, ring } (key)}
 						<button
 							class="flex flex-col items-center justify-center gap-1.5 rounded-lg border px-2 py-2.5 text-[10px] transition-all {readerTheme === key ? 'border-[var(--color-accent)] bg-[var(--color-accent)]/10 text-[var(--color-accent)]' : 'border-cream/[0.08] text-cream/40 hover:border-cream/20 hover:text-cream/60'}"
 							onclick={() => { settings.theme = key as ReaderSettings['theme']; }}
@@ -929,7 +929,7 @@
 			<div class="mb-5">
 				<span class="settings-label">Font</span>
 				<div class="grid grid-cols-4 gap-1.5">
-					{#each [{ key: 'serif', label: 'Serif', font: 'Georgia, serif' }, { key: 'sans', label: 'Sans', font: 'system-ui, sans-serif' }, { key: 'mono', label: 'Mono', font: "'JetBrains Mono', monospace" }, { key: 'dyslexic', label: 'Display', font: "'Playfair Display', Georgia, serif" }] as { key, label, font } (key)}
+					{#each [{ key: 'serif', label: 'Serif', font: 'Georgia, serif' }, { key: 'sans', label: 'Sans', font: 'system-ui, sans-serif' }, { key: 'mono', label: 'Mono', font: "'JetBrains Mono', monospace" }, { key: 'display', label: 'Display', font: "'Playfair Display', Georgia, serif" }] as { key, label, font } (key)}
 						<button
 							class="rounded-lg border px-2 py-2 text-xs transition-all {fontFamily === key ? 'border-[var(--color-accent)] bg-[var(--color-accent)]/10 text-[var(--color-accent)]' : 'border-cream/[0.08] text-cream/50 hover:border-cream/20 hover:text-cream/70'}"
 							style="font-family: {font};"
@@ -965,7 +965,7 @@
 			<div class="mb-5">
 				<span class="settings-label">Margins</span>
 				<div class="flex gap-2">
-					{#each [{ key: 'narrow', label: 'Narrow' }, { key: 'normal', label: 'Medium' }, { key: 'wide', label: 'Wide' }] as { key, label } (key)}
+					{#each [{ key: 'narrow', label: 'Narrow' }, { key: 'medium', label: 'Medium' }, { key: 'wide', label: 'Wide' }] as { key, label } (key)}
 						<button
 							class="flex-1 rounded-lg border px-3 py-2 text-xs transition-all {margins === key ? 'border-[var(--color-accent)] bg-[var(--color-accent)]/10 text-[var(--color-accent)]' : 'border-cream/[0.08] text-cream/50 hover:border-cream/20 hover:text-cream/70'}"
 							onclick={() => { settings.margins = key as ReaderSettings['margins']; }}

--- a/src/lib/components/books/PaginatedViewport.svelte
+++ b/src/lib/components/books/PaginatedViewport.svelte
@@ -1,0 +1,104 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import type { Snippet } from 'svelte';
+	import type { ReaderSettings } from './reader-settings';
+	import { resolveSpread } from './reader-settings';
+	import { useReaderInputs } from './useReaderInputs.svelte';
+
+	interface Props {
+		settings: ReaderSettings;
+		onPrev: () => void;
+		onNext: () => void;
+		onToggleUI: () => void;
+		children: Snippet<[{ effectiveSpread: 'single' | 'dual'; animationKey: number }]>;
+	}
+
+	let { settings, onPrev, onNext, onToggleUI, children }: Props = $props();
+
+	let containerEl = $state<HTMLDivElement | undefined>();
+	let viewportWidth = $state<number>(typeof window !== 'undefined' ? window.innerWidth : 1024);
+	let animationKey = $state<number>(0);
+
+	const effectiveSpread = $derived(resolveSpread(settings.spread, viewportWidth));
+
+	const inputs = useReaderInputs({
+		getSettings: () => settings,
+		onPrev: () => { animationKey++; onPrev(); },
+		onNext: () => { animationKey++; onNext(); },
+		onToggleUI: () => onToggleUI()
+	});
+
+	onMount(() => {
+		const onResize = () => { viewportWidth = window.innerWidth; };
+		window.addEventListener('resize', onResize);
+		const detach = inputs.attachKeyboard(window);
+		return () => {
+			window.removeEventListener('resize', onResize);
+			detach();
+		};
+	});
+
+	const animClass = $derived.by(() => {
+		if (settings.flow !== 'paginated') return '';
+		switch (settings.pageAnimation) {
+			case 'slide': return 'reader-anim-slide';
+			case 'fade': return 'reader-anim-fade';
+			default: return '';
+		}
+	});
+</script>
+
+<div
+	bind:this={containerEl}
+	class="reader-viewport {animClass}"
+	data-flow={settings.flow}
+	data-spread={effectiveSpread}
+	data-direction={settings.direction}
+	{...inputs.swipeHandlers}
+>
+	{#key animationKey}
+		<div class="reader-page-layer">
+			{@render children({ effectiveSpread, animationKey })}
+		</div>
+	{/key}
+	{#if settings.flow === 'paginated' && settings.inputs.tapZones}
+		<div class="reader-tap-overlay" {...inputs.tapHandlers} aria-hidden="true"></div>
+	{/if}
+</div>
+
+<style>
+	.reader-viewport {
+		position: relative;
+		width: 100%;
+		height: 100%;
+		overflow: hidden;
+		touch-action: pan-y;
+	}
+	.reader-viewport[data-flow='scrolled'] {
+		overflow-y: auto;
+	}
+	.reader-page-layer {
+		width: 100%;
+		height: 100%;
+	}
+	.reader-tap-overlay {
+		position: absolute;
+		inset: 0;
+		z-index: 5;
+		background: transparent;
+	}
+	.reader-anim-slide .reader-page-layer {
+		animation: reader-slide-in 220ms ease-out;
+	}
+	.reader-anim-fade .reader-page-layer {
+		animation: reader-fade-in 150ms ease-out;
+	}
+	@keyframes reader-slide-in {
+		from { transform: translateX(20%); opacity: 0; }
+		to { transform: translateX(0); opacity: 1; }
+	}
+	@keyframes reader-fade-in {
+		from { opacity: 0; }
+		to { opacity: 1; }
+	}
+</style>

--- a/src/lib/components/books/PaginatedViewport.svelte
+++ b/src/lib/components/books/PaginatedViewport.svelte
@@ -56,11 +56,17 @@
 	data-direction={settings.direction}
 	{...inputs.swipeHandlers}
 >
-	{#key animationKey}
-		<div class="reader-page-layer">
-			{@render children({ effectiveSpread, animationKey })}
-		</div>
-	{/key}
+	<!--
+		Do NOT wrap children in {#key animationKey}. EPUB's foliate-js host
+		is the same DOM node across pages; remounting it kills the iframe
+		mid-load and throws "Cannot read properties of null (reading 'head')".
+		Animations are driven by the CSS class plus the natural remount that
+		happens in PDF paginated mode (the page-card snippet keys on
+		currentPage and remounts each navigation).
+	-->
+	<div class="reader-page-layer">
+		{@render children({ effectiveSpread, animationKey })}
+	</div>
 	{#if settings.flow === 'paginated' && settings.inputs.tapZones}
 		<div class="reader-tap-overlay" {...inputs.tapHandlers} aria-hidden="true"></div>
 	{/if}

--- a/src/lib/components/books/PdfReader.svelte
+++ b/src/lib/components/books/PdfReader.svelte
@@ -643,7 +643,6 @@
 
 	// ── Page rendering ─────────────────────────────────────────────
 	async function renderPage(pageNum: number) {
-		console.log('[PdfReader] renderPage', pageNum, { hasDoc: !!pdfDoc, hasPdfjs: !!pdfjs, alreadyRendered: renderedPages.has(pageNum), inFlight: renderingPages.has(pageNum) });
 		if (!pdfDoc || !pdfjs || renderedPages.has(pageNum) || renderingPages.has(pageNum)) return;
 
 		// bind:this with array-indexing inside snippets is unreliable in
@@ -1060,24 +1059,18 @@
 	// observed empty by an effect that fires on the same tick as the snippet
 	// remount. This action runs *after* the canvas is in the DOM and the ref
 	// has been written, which is the only reliable signal to start rendering.
+	// Cache the canvas immediately on mount and kick off a render. bind:this
+	// with array indexing inside a snippet doesn't reliably populate the
+	// array slot before downstream effects observe it; this action does.
+	// queueMicrotask is used instead of requestAnimationFrame because RAF
+	// inside a Svelte action can be cancelled during the commit phase.
 	function onCanvasMount(node: HTMLCanvasElement, pageNum: number) {
-		console.log('[PdfReader] onCanvasMount fire', pageNum);
-		// Cache the canvas immediately so renderPage can find it via array
-		// indexing without relying on bind:this timing.
 		canvasRefs[pageNum - 1] = node;
-		// Try to render immediately if PDF is ready; if not, the existing
-		// loading-time scheduleBufferRender / paginated-mode $effect will
-		// retry once pdfDoc is set.
-		const tryRender = () => {
-			console.log('[PdfReader] tryRender exec', pageNum, { hasDoc: !!pdfDoc, loading });
+		queueMicrotask(() => {
 			if (!pdfDoc || loading) return;
 			if (settings.flow === 'paginated') renderedPages.delete(pageNum);
 			enqueueRender(pageNum);
-		};
-		// queueMicrotask is more reliable than RAF — RAF inside a Svelte action
-		// can be cancelled by the action's own destroy() during the synchronous
-		// commit phase.
-		queueMicrotask(tryRender);
+		});
 	}
 
 	// Dark mode filter for pages

--- a/src/lib/components/books/PdfReader.svelte
+++ b/src/lib/components/books/PdfReader.svelte
@@ -1074,6 +1074,7 @@
 		onBookmark={handleBookmark}
 		onToggleShortcuts={() => (showShortcuts = !showShortcuts)}
 		onFullscreen={toggleFullscreen}
+		onSettings={() => (showSettings = !showSettings)}
 	/>
 
 	<!-- ── Content area (sidebar + viewport) ──────────────────── -->

--- a/src/lib/components/books/PdfReader.svelte
+++ b/src/lib/components/books/PdfReader.svelte
@@ -654,7 +654,19 @@
 
 		try {
 			const page = await pdfDoc.getPage(pageNum);
-			const viewport = page.getViewport({ scale });
+			// In paginated mode, fit each page to the viewport (halved for dual);
+			// in scrolled mode, the user-controlled scale governs.
+			let renderScale = scale;
+			if (settings.flow === 'paginated' && viewportEl) {
+				const containerW = Math.max(0, viewportEl.clientWidth - 80);
+				const containerH = Math.max(0, viewportEl.clientHeight - 40);
+				const pagesAcross = effectiveSpread === 'dual' ? 2 : 1;
+				const baseVp = page.getViewport({ scale: 1 });
+				const fitW = (containerW / pagesAcross) / baseVp.width;
+				const fitH = containerH / baseVp.height;
+				renderScale = Math.min(fitW, fitH);
+			}
+			const viewport = page.getViewport({ scale: renderScale });
 			const dpr = window.devicePixelRatio || 1;
 
 			// Size the canvas
@@ -1006,9 +1018,50 @@
 	function getPageDims(pageIdx: number): { width: number; height: number } {
 		const vp = pageViewports[pageIdx];
 		if (!vp) return { width: 600, height: 800 };
+		// In paginated dual mode, halve the per-page width so two pages fit side
+		// by side. In paginated single mode, scale-down so a single page fills
+		// the viewport without overflow.
+		let dimScale = scale;
+		if (settings.flow === 'paginated' && viewportEl) {
+			const containerW = Math.max(0, viewportEl.clientWidth - 80);
+			const containerH = Math.max(0, viewportEl.clientHeight - 40);
+			const pagesAcross = effectiveSpread === 'dual' ? 2 : 1;
+			const fitW = (containerW / pagesAcross) / vp.width;
+			const fitH = containerH / vp.height;
+			dimScale = Math.min(fitW, fitH);
+		}
 		return {
-			width: vp.width * scale,
-			height: vp.height * scale
+			width: vp.width * dimScale,
+			height: vp.height * dimScale
+		};
+	}
+
+	// Fire renderPage when each canvas actually mounts. bind:this with array
+	// indexing inside a snippet is fragile in Svelte 5 — the array slot can be
+	// observed empty by an effect that fires on the same tick as the snippet
+	// remount. This action runs *after* the canvas is in the DOM and the ref
+	// has been written, which is the only reliable signal to start rendering.
+	function onCanvasMount(node: HTMLCanvasElement, pageNum: number) {
+		const tryRender = () => {
+			if (!pdfDoc || loading) return;
+			if (settings.flow === 'paginated') {
+				renderedPages.delete(pageNum);
+				enqueueRender(pageNum);
+			} else {
+				enqueueRender(pageNum);
+			}
+		};
+		// Defer one frame so dims/scale settle.
+		const raf = requestAnimationFrame(tryRender);
+		return {
+			update(newPageNum: number) {
+				cancelAnimationFrame(raf);
+				pageNum = newPageNum;
+				requestAnimationFrame(tryRender);
+			},
+			destroy() {
+				cancelAnimationFrame(raf);
+			}
 		};
 	}
 
@@ -1032,7 +1085,10 @@
 		style="width: {dims.width}px; height: {dims.height}px; filter: {pageFilter};"
 		bind:this={pageWrappers[pageNum - 1]}
 	>
-		<canvas bind:this={canvasRefs[pageNum - 1]}></canvas>
+		<canvas
+			bind:this={canvasRefs[pageNum - 1]}
+			use:onCanvasMount={pageNum}
+		></canvas>
 		<div class="text-layer" bind:this={textLayerRefs[pageNum - 1]}></div>
 		{#if !renderedPages.has(pageNum)}
 			<div class="page-placeholder">

--- a/src/lib/components/books/PdfReader.svelte
+++ b/src/lib/components/books/PdfReader.svelte
@@ -645,9 +645,27 @@
 	async function renderPage(pageNum: number) {
 		if (!pdfDoc || !pdfjs || renderedPages.has(pageNum) || renderingPages.has(pageNum)) return;
 
+		// bind:this with array-indexing inside snippets is unreliable in
+		// Svelte 5 — the array slot can read empty here even when the canvas
+		// is fully mounted. Fall back to a DOM lookup keyed off data-page,
+		// which works for both paginated and scrolled modes since both
+		// render `<div class="page-wrapper" data-page={n}>`.
 		const idx = pageNum - 1;
-		const canvas = canvasRefs[idx];
-		const textDiv = textLayerRefs[idx];
+		let canvas = canvasRefs[idx];
+		let textDiv = textLayerRefs[idx];
+		if (!canvas || !textDiv) {
+			const wrapper = document.querySelector<HTMLElement>(`.page-wrapper[data-page="${pageNum}"]`);
+			if (wrapper) {
+				const c = wrapper.querySelector('canvas') as HTMLCanvasElement | null;
+				const t = wrapper.querySelector('.text-layer') as HTMLDivElement | null;
+				if (c && t) {
+					canvas = c;
+					textDiv = t;
+					canvasRefs[idx] = c;
+					textLayerRefs[idx] = t;
+				}
+			}
+		}
 		if (!canvas || !textDiv) return;
 
 		renderingPages.add(pageNum);

--- a/src/lib/components/books/PdfReader.svelte
+++ b/src/lib/components/books/PdfReader.svelte
@@ -7,7 +7,7 @@
 	// actual module load until initPdf() runs. See the `pdfjs` variable
 	// below for the lazily-loaded module handle.
 	import type { PDFDocumentProxy, PageViewport, RenderTask } from 'pdfjs-dist';
-	import { Loader2 } from 'lucide-svelte';
+	import { Loader2, X } from 'lucide-svelte';
 	import { SvelteSet, SvelteMap } from 'svelte/reactivity';
 	import PdfToolbar from './PdfToolbar.svelte';
 	import PdfSidebar from './PdfSidebar.svelte';
@@ -18,6 +18,14 @@
 	import KeyboardShortcuts from './KeyboardShortcuts.svelte';
 	import PdfMinimap from './PdfMinimap.svelte';
 	import MarginNotes from './MarginNotes.svelte';
+	import PaginatedViewport from './PaginatedViewport.svelte';
+	import ReaderSettingsPanel from './ReaderSettingsPanel.svelte';
+	import {
+		type ReaderSettings,
+		loadReaderSettings,
+		persistReaderSettings,
+		resolveSpread
+	} from './reader-settings';
 
 	// ── Props ──────────────────────────────────────────────────────
 	interface Props {
@@ -57,7 +65,10 @@
 	let fitMode = $state<'width' | 'page' | 'custom'>('width');
 	let showToolbar = $state(true);
 	let showSidebar = $state(false);
-	let spreadMode = $state<'single' | 'dual'>('single');
+	let showSettings = $state(false);
+	let settings = $state<ReaderSettings>(loadReaderSettings());
+	let viewportWidth = $state<number>(browser ? window.innerWidth : 1024);
+	const effectiveSpread = $derived(resolveSpread(settings.spread, viewportWidth));
 	let darkMode = $state<'light' | 'dark' | 'sepia'>('light');
 	let showRuler = $state(false);
 	let showShortcuts = $state(false);
@@ -164,8 +175,11 @@
 	}
 
 	function goToPage(page: number) {
-		if (page < 1 || page > numPages || !viewportEl) return;
-		if (spreadMode === 'dual') {
+		if (page < 1 || page > numPages) return;
+		currentPage = page;
+		if (settings.flow === 'paginated') return;
+		if (!viewportEl) return;
+		if (effectiveSpread === 'dual') {
 			// Find the pair container that contains this page
 			const pairIdx = page === 1 ? 0 : Math.ceil((page - 1) / 2);
 			const pairEl = viewportEl.querySelector(`[data-pair="${pairIdx}"]`);
@@ -182,7 +196,17 @@
 
 	/** In dual mode, jump by 2 pages; in single mode, jump by 1 */
 	function pageStep(): number {
-		return spreadMode === 'dual' ? 2 : 1;
+		return effectiveSpread === 'dual' ? 2 : 1;
+	}
+
+	function goPrevPage() {
+		const step = effectiveSpread === 'dual' ? 2 : 1;
+		currentPage = Math.max(1, currentPage - step);
+	}
+
+	function goNextPage() {
+		const step = effectiveSpread === 'dual' ? 2 : 1;
+		currentPage = Math.min(numPages, currentPage + step);
 	}
 
 	// ── Zoom functions ────────────────────────────────────────────
@@ -200,7 +224,7 @@
 		if (!pdfDoc || pageViewports.length === 0) return;
 		const vp = pageViewports[0];
 		const containerWidth = (viewportEl?.clientWidth ?? 800) - 80;
-		if (spreadMode === 'dual') {
+		if (effectiveSpread === 'dual') {
 			// Fit two pages side-by-side with 16px gap
 			scale = (containerWidth - 16) / (2 * vp.width);
 		} else {
@@ -215,7 +239,7 @@
 		const containerWidth = viewportEl.clientWidth - 80;
 		const containerHeight = viewportEl.clientHeight - 80;
 		let scaleW: number;
-		if (spreadMode === 'dual') {
+		if (effectiveSpread === 'dual') {
 			scaleW = (containerWidth - 16) / (2 * vp.width);
 		} else {
 			scaleW = containerWidth / vp.width;
@@ -231,10 +255,7 @@
 	}
 
 	function handleSpreadMode(mode: 'single' | 'dual') {
-		spreadMode = mode;
-		// Recalculate scale for the new spread mode
-		if (fitMode === 'width') fitWidth();
-		else if (fitMode === 'page') fitPage();
+		settings.spread = mode;
 	}
 
 	function handleDarkMode(mode: 'light' | 'dark' | 'sepia') {
@@ -445,11 +466,14 @@
 				break;
 			case 'ArrowDown':
 			case 'PageDown':
+				// In paginated mode, PaginatedViewport's keyboard handler owns nav keys.
+				if (settings.flow === 'paginated' && settings.inputs.keyboard) break;
 				e.preventDefault();
 				goToPage(currentPage + pageStep());
 				break;
 			case 'ArrowUp':
 			case 'PageUp':
+				if (settings.flow === 'paginated' && settings.inputs.keyboard) break;
 				e.preventDefault();
 				goToPage(currentPage - pageStep());
 				break;
@@ -501,6 +525,8 @@
 	// ── Scroll tracking ────────────────────────────────────────────
 	function handleScroll() {
 		if (!viewportEl || numPages === 0) return;
+		// Scroll tracking only applies in scrolled mode.
+		if (settings.flow !== 'scrolled') return;
 
 		// Debounce scroll tracking
 		if (scrollTimer) clearTimeout(scrollTimer);
@@ -548,8 +574,19 @@
 	}
 
 	function scheduleBufferRender() {
-		const start = Math.max(1, currentPage - BUFFER_PAGES);
-		const end = Math.min(numPages, currentPage + BUFFER_PAGES);
+		// In paginated mode we only render the current page (and optionally the
+		// second page of a dual spread). Keep a 1-page buffer on either side so
+		// quick navigation doesn't flash a placeholder.
+		let start: number;
+		let end: number;
+		if (settings.flow === 'paginated') {
+			const span = effectiveSpread === 'dual' ? 1 : 0;
+			start = Math.max(1, currentPage - 1);
+			end = Math.min(numPages, currentPage + span + 1);
+		} else {
+			start = Math.max(1, currentPage - BUFFER_PAGES);
+			end = Math.min(numPages, currentPage + BUFFER_PAGES);
+		}
 
 		// Clean up pages outside the buffer
 		for (const pageNum of renderedPages) {
@@ -805,7 +842,7 @@
 			if (wrapper) observer.observe(wrapper);
 		}
 		// In dual mode, also observe pair containers
-		if (spreadMode === 'dual') {
+		if (effectiveSpread === 'dual') {
 			const pairs = viewportEl.querySelectorAll('[data-pair]');
 			for (const pair of pairs) {
 				observer.observe(pair);
@@ -857,18 +894,47 @@
 		}
 	});
 
-	// ── Re-setup observer on spread mode change ──────────────────
+	// ── Re-setup observer on spread/flow change ──────────────────
 	$effect(() => {
-		// Track spreadMode to re-observe when layout changes
-		const _mode = spreadMode;
+		// Track effectiveSpread + flow to re-observe when layout changes
+		const _spread = effectiveSpread;
+		const _flow = settings.flow;
+		void _spread; void _flow;
 		if (!pdfDoc || loading) return;
-		// Wait for DOM to update after spread mode switch
+		// Wait for DOM to update after layout switch
 		requestAnimationFrame(() => {
 			if (observer) {
 				observer.disconnect();
 			}
 			setupObserver();
 			invalidateAllPages();
+		});
+	});
+
+	// ── Persist reader settings ──────────────────────────────────
+	$effect(() => {
+		persistReaderSettings(settings);
+	});
+
+	// ── Track viewport width for auto spread ─────────────────────
+	$effect(() => {
+		if (!browser) return;
+		const onResize = () => { viewportWidth = window.innerWidth; };
+		window.addEventListener('resize', onResize);
+		return () => window.removeEventListener('resize', onResize);
+	});
+
+	// ── Render visible page(s) in paginated mode on currentPage change ──
+	$effect(() => {
+		const page = currentPage;
+		const dual = effectiveSpread === 'dual';
+		if (!pdfDoc || loading) return;
+		if (settings.flow !== 'paginated') return;
+		// Let the DOM mount the new page wrapper(s) before enqueueing.
+		requestAnimationFrame(() => {
+			enqueueRender(page);
+			if (dual && page + 1 <= numPages) enqueueRender(page + 1);
+			scheduleBufferRender();
 		});
 	});
 
@@ -950,6 +1016,30 @@
 
 <svelte:window onkeydown={handleKeydown} />
 
+{#snippet pageCard(pageNum: number)}
+	{@const dims = getPageDims(pageNum - 1)}
+	<div
+		class="page-wrapper"
+		data-page={pageNum}
+		style="width: {dims.width}px; height: {dims.height}px; filter: {pageFilter};"
+		bind:this={pageWrappers[pageNum - 1]}
+	>
+		<canvas bind:this={canvasRefs[pageNum - 1]}></canvas>
+		<div class="text-layer" bind:this={textLayerRefs[pageNum - 1]}></div>
+		{#if !renderedPages.has(pageNum)}
+			<div class="page-placeholder">
+				<span class="page-placeholder-num">{pageNum}</span>
+			</div>
+		{/if}
+		{#if localBookmarks.has(pageNum)}
+			<div class="bookmark-ribbon"></div>
+		{/if}
+		{#if highlightedPages.has(pageNum)}
+			<div class="highlight-indicator"></div>
+		{/if}
+	</div>
+{/snippet}
+
 <div
 	class="pdf-reader"
 	onmousemove={handleMouseMove}
@@ -964,7 +1054,7 @@
 		totalPages={numPages}
 		{scale}
 		{fitMode}
-		{spreadMode}
+		spreadMode={effectiveSpread}
 		{darkMode}
 		{showSidebar}
 		{searchQuery}
@@ -1029,64 +1119,44 @@
 					<p class="error-detail">{loadError}</p>
 					<button onclick={() => initPdf()} class="error-retry">Retry</button>
 				</div>
+			{:else if settings.flow === 'paginated'}
+				<PaginatedViewport
+					{settings}
+					onPrev={goPrevPage}
+					onNext={goNextPage}
+					onToggleUI={() => { showSettings = !showSettings; }}
+				>
+					{#snippet children({ effectiveSpread: es })}
+						<div class="pages-container pages-paginated" class:spread-dual={es === 'dual'}>
+							{#if es === 'dual'}
+								<div class="page-pair">
+									{@render pageCard(currentPage)}
+									{#if currentPage + 1 <= numPages}
+										{@render pageCard(currentPage + 1)}
+									{/if}
+								</div>
+							{:else}
+								{@render pageCard(currentPage)}
+							{/if}
+						</div>
+					{/snippet}
+				</PaginatedViewport>
+			{:else if effectiveSpread === 'dual'}
+				<div class="pages-container spread-dual">
+					{#each pagePairs as pair, pairIdx (pairIdx)}
+						<div class="page-pair" data-pair={pairIdx}>
+							{#each pair as pageNum (pageNum)}
+								{@render pageCard(pageNum)}
+							{/each}
+						</div>
+					{/each}
+				</div>
 			{:else}
-				{#if spreadMode === 'dual'}
-					<div class="pages-container spread-dual">
-						{#each pagePairs as pair, pairIdx (pairIdx)}
-							<div class="page-pair" data-pair={pairIdx}>
-								{#each pair as pageNum (pageNum)}
-									{@const dims = getPageDims(pageNum - 1)}
-									<div
-										class="page-wrapper"
-										data-page={pageNum}
-										style="width: {dims.width}px; height: {dims.height}px; filter: {pageFilter};"
-										bind:this={pageWrappers[pageNum - 1]}
-									>
-										<canvas bind:this={canvasRefs[pageNum - 1]}></canvas>
-										<div class="text-layer" bind:this={textLayerRefs[pageNum - 1]}></div>
-										{#if !renderedPages.has(pageNum)}
-											<div class="page-placeholder">
-												<span class="page-placeholder-num">{pageNum}</span>
-											</div>
-										{/if}
-										{#if localBookmarks.has(pageNum)}
-											<div class="bookmark-ribbon"></div>
-										{/if}
-										{#if highlightedPages.has(pageNum)}
-											<div class="highlight-indicator"></div>
-										{/if}
-									</div>
-								{/each}
-							</div>
-						{/each}
-					</div>
-				{:else}
-					<div class="pages-container">
-						{#each Array(numPages) as _, i (i)}
-							{@const dims = getPageDims(i)}
-							<div
-								class="page-wrapper"
-								data-page={i + 1}
-								style="width: {dims.width}px; height: {dims.height}px; filter: {pageFilter};"
-								bind:this={pageWrappers[i]}
-							>
-								<canvas bind:this={canvasRefs[i]}></canvas>
-								<div class="text-layer" bind:this={textLayerRefs[i]}></div>
-								{#if !renderedPages.has(i + 1)}
-									<div class="page-placeholder">
-										<span class="page-placeholder-num">{i + 1}</span>
-									</div>
-								{/if}
-								{#if localBookmarks.has(i + 1)}
-									<div class="bookmark-ribbon"></div>
-								{/if}
-								{#if highlightedPages.has(i + 1)}
-									<div class="highlight-indicator"></div>
-								{/if}
-							</div>
-						{/each}
-					</div>
-				{/if}
+				<div class="pages-container">
+					{#each Array(numPages) as _, i (i)}
+						{@render pageCard(i + 1)}
+					{/each}
+				</div>
 			{/if}
 
 			<!-- ── Reading Ruler ──────────────────────────────────── -->
@@ -1159,6 +1229,22 @@
 			<div class="note-actions">
 				<button class="note-btn note-cancel" onclick={() => { showNoteInput = false; noteInputText = ''; }}>Cancel</button>
 				<button class="note-btn note-save" onclick={submitNote}>Save Note</button>
+			</div>
+		</div>
+	{/if}
+
+	<!-- ── Settings Drawer ────────────────────────────────────── -->
+	{#if showSettings}
+		<!-- svelte-ignore a11y_no_static_element_interactions -->
+		<div class="fixed inset-0 z-[70] bg-black/40" onclick={() => (showSettings = false)} onkeydown={(e) => { if (e.key === 'Escape') showSettings = false; }} role="button" tabindex="-1" aria-label="Close settings">
+			<div class="absolute bottom-0 right-0 top-0 w-80 max-w-[85vw] overflow-y-auto border-l border-cream/[0.06] p-5" style="background: rgba(20, 18, 16, 0.97); backdrop-filter: blur(24px);" onclick={(e) => e.stopPropagation()} onkeydown={(e) => e.stopPropagation()} role="dialog" tabindex="-1" aria-label="Reader settings">
+				<div class="mb-5 flex items-center justify-between">
+					<h2 class="text-sm font-semibold tracking-wide text-cream/90">Reading Settings</h2>
+					<button onclick={() => (showSettings = false)} class="rounded-lg p-1.5 text-cream/50 hover:bg-cream/[0.06] hover:text-cream" aria-label="Close">
+						<X size={16} strokeWidth={1.5} />
+					</button>
+				</div>
+				<ReaderSettingsPanel bind:settings variant="pdf" />
 			</div>
 		</div>
 	{/if}
@@ -1505,5 +1591,12 @@
 
 	.note-save:hover {
 		opacity: 0.9;
+	}
+
+	/* ── Paginated single-page centering ───────────────────── */
+	.pages-paginated {
+		justify-content: center;
+		min-height: 100%;
+		padding: 24px 40px;
 	}
 </style>

--- a/src/lib/components/books/PdfReader.svelte
+++ b/src/lib/components/books/PdfReader.svelte
@@ -62,6 +62,10 @@
 	let numPages = $state(0);
 	let currentPage = $state(1);
 	let scale = $state(1);
+	// In paginated mode the page is auto-fit to the viewport; this multiplier
+	// lets the user zoom in/out from that baseline (1.0 = exact fit). Scrolled
+	// mode continues to use `scale` directly.
+	let paginatedZoom = $state(1);
 	let fitMode = $state<'width' | 'page' | 'custom'>('width');
 	let showToolbar = $state(true);
 	let showSidebar = $state(false);
@@ -211,11 +215,23 @@
 
 	// ── Zoom functions ────────────────────────────────────────────
 	function zoomIn() {
+		if (settings.flow === 'paginated') {
+			paginatedZoom = Math.min(5.0, paginatedZoom * 1.25);
+			invalidateAllPages();
+			scheduleBufferRender();
+			return;
+		}
 		fitMode = 'custom';
 		scale = Math.min(5.0, scale * 1.25);
 	}
 
 	function zoomOut() {
+		if (settings.flow === 'paginated') {
+			paginatedZoom = Math.max(0.25, paginatedZoom * 0.8);
+			invalidateAllPages();
+			scheduleBufferRender();
+			return;
+		}
 		fitMode = 'custom';
 		scale = Math.max(0.25, scale * 0.8);
 	}
@@ -682,7 +698,7 @@
 				const baseVp = page.getViewport({ scale: 1 });
 				const fitW = (containerW / pagesAcross) / baseVp.width;
 				const fitH = containerH / baseVp.height;
-				renderScale = Math.min(fitW, fitH);
+				renderScale = Math.min(fitW, fitH) * paginatedZoom;
 			}
 			const viewport = page.getViewport({ scale: renderScale });
 			const dpr = window.devicePixelRatio || 1;
@@ -1046,7 +1062,7 @@
 			const pagesAcross = effectiveSpread === 'dual' ? 2 : 1;
 			const fitW = (containerW / pagesAcross) / vp.width;
 			const fitH = containerH / vp.height;
-			dimScale = Math.min(fitW, fitH);
+			dimScale = Math.min(fitW, fitH) * paginatedZoom;
 		}
 		return {
 			width: vp.width * dimScale,
@@ -1124,7 +1140,7 @@
 		bookAuthor={book.metadata?.author as string | undefined}
 		{currentPage}
 		totalPages={numPages}
-		{scale}
+		scale={settings.flow === 'paginated' ? paginatedZoom : scale}
 		{fitMode}
 		spreadMode={effectiveSpread}
 		{darkMode}

--- a/src/lib/components/books/PdfReader.svelte
+++ b/src/lib/components/books/PdfReader.svelte
@@ -925,11 +925,19 @@
 	});
 
 	// ── Render visible page(s) in paginated mode on currentPage change ──
+	// PaginatedViewport wraps the page-card snippet in {#key animationKey} so
+	// each navigation destroys and remounts the canvas. The render cache
+	// (renderedPages) survives that remount, so on revisit we'd skip the
+	// re-render and show an empty canvas. Evict the visible pages first, then
+	// enqueue, so they always paint onto the freshly-mounted canvas.
 	$effect(() => {
 		const page = currentPage;
 		const dual = effectiveSpread === 'dual';
+		const flow = settings.flow;
 		if (!pdfDoc || loading) return;
-		if (settings.flow !== 'paginated') return;
+		if (flow !== 'paginated') return;
+		renderedPages.delete(page);
+		if (dual && page + 1 <= numPages) renderedPages.delete(page + 1);
 		// Let the DOM mount the new page wrapper(s) before enqueueing.
 		requestAnimationFrame(() => {
 			enqueueRender(page);

--- a/src/lib/components/books/PdfReader.svelte
+++ b/src/lib/components/books/PdfReader.svelte
@@ -217,11 +217,7 @@
 	function zoomIn() {
 		if (settings.flow === 'paginated') {
 			paginatedZoom = Math.min(5.0, paginatedZoom * 1.25);
-			console.log('[PdfReader] zoomIn paginated', paginatedZoom, 'rendered=', [...renderedPages], 'renderingPages=', [...renderingPages]);
 			invalidateAllPages();
-			console.log('[PdfReader] after invalidate rendered=', [...renderedPages]);
-			scheduleBufferRender();
-			console.log('[PdfReader] after scheduleBufferRender queue=', [...renderQueue]);
 			return;
 		}
 		fitMode = 'custom';
@@ -232,7 +228,6 @@
 		if (settings.flow === 'paginated') {
 			paginatedZoom = Math.max(0.25, paginatedZoom * 0.8);
 			invalidateAllPages();
-			scheduleBufferRender();
 			return;
 		}
 		fitMode = 'custom';
@@ -653,7 +648,14 @@
 
 	// ── Invalidate all rendered pages (for scale change) ──────────
 	function invalidateAllPages() {
-		for (const pageNum of [...renderedPages]) {
+		// Pages that finished rendering AND pages currently in flight both need
+		// to be invalidated when scale changes. cleanupPage handles both —
+		// cancels any active render task and clears the canvas — so iterate
+		// the union of both sets.
+		const pages = new Set<number>();
+		for (const p of renderedPages) pages.add(p);
+		for (const p of renderingPages) pages.add(p);
+		for (const pageNum of pages) {
 			cleanupPage(pageNum);
 		}
 		renderQueue = [];
@@ -662,11 +664,7 @@
 
 	// ── Page rendering ─────────────────────────────────────────────
 	async function renderPage(pageNum: number) {
-		console.log('[PdfReader] renderPage entry', pageNum, 'paginatedZoom=', paginatedZoom);
-		if (!pdfDoc || !pdfjs || renderedPages.has(pageNum) || renderingPages.has(pageNum)) {
-			console.log('[PdfReader] renderPage early-return', pageNum, { rendered: renderedPages.has(pageNum), rendering: renderingPages.has(pageNum) });
-			return;
-		}
+		if (!pdfDoc || !pdfjs || renderedPages.has(pageNum) || renderingPages.has(pageNum)) return;
 
 		// bind:this with array-indexing inside snippets is unreliable in
 		// Svelte 5 — the array slot can read empty here even when the canvas

--- a/src/lib/components/books/PdfReader.svelte
+++ b/src/lib/components/books/PdfReader.svelte
@@ -217,8 +217,11 @@
 	function zoomIn() {
 		if (settings.flow === 'paginated') {
 			paginatedZoom = Math.min(5.0, paginatedZoom * 1.25);
+			console.log('[PdfReader] zoomIn paginated', paginatedZoom, 'rendered=', [...renderedPages], 'renderingPages=', [...renderingPages]);
 			invalidateAllPages();
+			console.log('[PdfReader] after invalidate rendered=', [...renderedPages]);
 			scheduleBufferRender();
+			console.log('[PdfReader] after scheduleBufferRender queue=', [...renderQueue]);
 			return;
 		}
 		fitMode = 'custom';
@@ -659,7 +662,11 @@
 
 	// ── Page rendering ─────────────────────────────────────────────
 	async function renderPage(pageNum: number) {
-		if (!pdfDoc || !pdfjs || renderedPages.has(pageNum) || renderingPages.has(pageNum)) return;
+		console.log('[PdfReader] renderPage entry', pageNum, 'paginatedZoom=', paginatedZoom);
+		if (!pdfDoc || !pdfjs || renderedPages.has(pageNum) || renderingPages.has(pageNum)) {
+			console.log('[PdfReader] renderPage early-return', pageNum, { rendered: renderedPages.has(pageNum), rendering: renderingPages.has(pageNum) });
+			return;
+		}
 
 		// bind:this with array-indexing inside snippets is unreliable in
 		// Svelte 5 — the array slot can read empty here even when the canvas

--- a/src/lib/components/books/PdfReader.svelte
+++ b/src/lib/components/books/PdfReader.svelte
@@ -643,6 +643,7 @@
 
 	// ── Page rendering ─────────────────────────────────────────────
 	async function renderPage(pageNum: number) {
+		console.log('[PdfReader] renderPage', pageNum, { hasDoc: !!pdfDoc, hasPdfjs: !!pdfjs, alreadyRendered: renderedPages.has(pageNum), inFlight: renderingPages.has(pageNum) });
 		if (!pdfDoc || !pdfjs || renderedPages.has(pageNum) || renderingPages.has(pageNum)) return;
 
 		// bind:this with array-indexing inside snippets is unreliable in
@@ -1060,7 +1061,9 @@
 	// remount. This action runs *after* the canvas is in the DOM and the ref
 	// has been written, which is the only reliable signal to start rendering.
 	function onCanvasMount(node: HTMLCanvasElement, pageNum: number) {
+		console.log('[PdfReader] onCanvasMount', pageNum, { hasDoc: !!pdfDoc, loading });
 		const tryRender = () => {
+			console.log('[PdfReader] tryRender RAF', pageNum, { hasDoc: !!pdfDoc, loading, flow: settings.flow });
 			if (!pdfDoc || loading) return;
 			if (settings.flow === 'paginated') {
 				renderedPages.delete(pageNum);

--- a/src/lib/components/books/PdfReader.svelte
+++ b/src/lib/components/books/PdfReader.svelte
@@ -1061,29 +1061,23 @@
 	// remount. This action runs *after* the canvas is in the DOM and the ref
 	// has been written, which is the only reliable signal to start rendering.
 	function onCanvasMount(node: HTMLCanvasElement, pageNum: number) {
-		console.log('[PdfReader] onCanvasMount', pageNum, { hasDoc: !!pdfDoc, loading });
+		console.log('[PdfReader] onCanvasMount fire', pageNum);
+		// Cache the canvas immediately so renderPage can find it via array
+		// indexing without relying on bind:this timing.
+		canvasRefs[pageNum - 1] = node;
+		// Try to render immediately if PDF is ready; if not, the existing
+		// loading-time scheduleBufferRender / paginated-mode $effect will
+		// retry once pdfDoc is set.
 		const tryRender = () => {
-			console.log('[PdfReader] tryRender RAF', pageNum, { hasDoc: !!pdfDoc, loading, flow: settings.flow });
+			console.log('[PdfReader] tryRender exec', pageNum, { hasDoc: !!pdfDoc, loading });
 			if (!pdfDoc || loading) return;
-			if (settings.flow === 'paginated') {
-				renderedPages.delete(pageNum);
-				enqueueRender(pageNum);
-			} else {
-				enqueueRender(pageNum);
-			}
+			if (settings.flow === 'paginated') renderedPages.delete(pageNum);
+			enqueueRender(pageNum);
 		};
-		// Defer one frame so dims/scale settle.
-		const raf = requestAnimationFrame(tryRender);
-		return {
-			update(newPageNum: number) {
-				cancelAnimationFrame(raf);
-				pageNum = newPageNum;
-				requestAnimationFrame(tryRender);
-			},
-			destroy() {
-				cancelAnimationFrame(raf);
-			}
-		};
+		// queueMicrotask is more reliable than RAF — RAF inside a Svelte action
+		// can be cancelled by the action's own destroy() during the synchronous
+		// commit phase.
+		queueMicrotask(tryRender);
 	}
 
 	// Dark mode filter for pages

--- a/src/lib/components/books/PdfToolbar.svelte
+++ b/src/lib/components/books/PdfToolbar.svelte
@@ -2,7 +2,7 @@
 	import {
 		ArrowLeft, PanelLeft, ZoomIn, ZoomOut, Sun, Moon, Search,
 		ChevronUp, ChevronDown, Bookmark, Keyboard, Maximize,
-		BookOpen, File
+		BookOpen, File, Settings
 	} from 'lucide-svelte';
 
 	interface Props {
@@ -33,6 +33,7 @@
 		onBookmark: () => void;
 		onToggleShortcuts: () => void;
 		onFullscreen: () => void;
+		onSettings: () => void;
 	}
 
 	let {
@@ -62,7 +63,8 @@
 		onSearchPrev,
 		onBookmark,
 		onToggleShortcuts,
-		onFullscreen
+		onFullscreen,
+		onSettings
 	}: Props = $props();
 
 	let localSearchValue = $state('');
@@ -233,6 +235,11 @@
 		title="Bookmark this page"
 	>
 		<Bookmark size={18} strokeWidth={1.5} fill={isBookmarked ? 'var(--color-warm)' : 'none'} />
+	</button>
+
+	<!-- Reader settings -->
+	<button class="tb-btn" onclick={onSettings} title="Reader settings">
+		<Settings size={18} strokeWidth={1.5} />
 	</button>
 
 	<!-- Shortcuts -->

--- a/src/lib/components/books/ReaderSettingsPanel.svelte
+++ b/src/lib/components/books/ReaderSettingsPanel.svelte
@@ -1,0 +1,162 @@
+<script lang="ts">
+	import type { ReaderSettings } from './reader-settings';
+
+	interface Props {
+		settings: ReaderSettings;
+		variant?: 'epub' | 'pdf';
+	}
+
+	let { settings = $bindable(), variant = 'epub' }: Props = $props();
+
+	const flowOptions: Array<{ value: ReaderSettings['flow']; label: string }> = [
+		{ value: 'paginated', label: 'Paginated' },
+		{ value: 'scrolled', label: 'Scrolled' }
+	];
+	const spreadOptions: Array<{ value: ReaderSettings['spread']; label: string }> = [
+		{ value: 'auto', label: 'Auto' },
+		{ value: 'single', label: 'Single' },
+		{ value: 'dual', label: 'Dual' }
+	];
+	const animOptions: Array<{ value: ReaderSettings['pageAnimation']; label: string }> = [
+		{ value: 'slide', label: 'Slide' },
+		{ value: 'fade', label: 'Fade' },
+		{ value: 'none', label: 'None' }
+	];
+	const dirOptions: Array<{ value: ReaderSettings['direction']; label: string }> = [
+		{ value: 'ltr', label: 'Left → Right' },
+		{ value: 'rtl', label: 'Right → Left' }
+	];
+</script>
+
+<div class="reader-settings space-y-5">
+	<section>
+		<h3 class="settings-heading">Page flow</h3>
+		<div class="settings-row">
+			{#each flowOptions as opt}
+				<button
+					type="button"
+					class="settings-pill"
+					class:settings-pill--active={settings.flow === opt.value}
+					onclick={() => { settings.flow = opt.value; }}
+				>{opt.label}</button>
+			{/each}
+		</div>
+	</section>
+
+	<section>
+		<h3 class="settings-heading">Spread</h3>
+		<div class="settings-row">
+			{#each spreadOptions as opt}
+				<button
+					type="button"
+					class="settings-pill"
+					class:settings-pill--active={settings.spread === opt.value}
+					onclick={() => { settings.spread = opt.value; }}
+				>{opt.label}</button>
+			{/each}
+		</div>
+		<p class="settings-hint">Auto picks dual on tablets/desktop, single on phones.</p>
+	</section>
+
+	<section>
+		<h3 class="settings-heading">Page animation</h3>
+		<div class="settings-row">
+			{#each animOptions as opt}
+				<button
+					type="button"
+					class="settings-pill"
+					class:settings-pill--active={settings.pageAnimation === opt.value}
+					onclick={() => { settings.pageAnimation = opt.value; }}
+				>{opt.label}</button>
+			{/each}
+		</div>
+	</section>
+
+	<section>
+		<h3 class="settings-heading">Inputs</h3>
+		<label class="settings-toggle">
+			<input type="checkbox" bind:checked={settings.inputs.tapZones} />
+			<span>Tap zones (left/middle/right)</span>
+		</label>
+		<label class="settings-toggle">
+			<input type="checkbox" bind:checked={settings.inputs.swipe} />
+			<span>Swipe</span>
+		</label>
+		<label class="settings-toggle">
+			<input type="checkbox" bind:checked={settings.inputs.keyboard} />
+			<span>Keyboard (← → PgUp PgDn Space)</span>
+		</label>
+	</section>
+
+	<section>
+		<h3 class="settings-heading">Direction</h3>
+		<div class="settings-row">
+			{#each dirOptions as opt}
+				<button
+					type="button"
+					class="settings-pill"
+					class:settings-pill--active={settings.direction === opt.value}
+					onclick={() => { settings.direction = opt.value; }}
+				>{opt.label}</button>
+			{/each}
+		</div>
+	</section>
+
+	{#if variant === 'epub'}
+		<section>
+			<h3 class="settings-heading">Font size</h3>
+			<input
+				type="range" min="12" max="32" step="1"
+				bind:value={settings.fontSize}
+				class="w-full"
+			/>
+			<p class="settings-hint">{settings.fontSize}px</p>
+		</section>
+	{/if}
+</div>
+
+<style>
+	.settings-heading {
+		font-size: 0.7rem;
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+		color: rgb(255 247 230 / 0.45);
+		margin-bottom: 0.5rem;
+	}
+	.settings-row {
+		display: flex;
+		gap: 0.4rem;
+	}
+	.settings-pill {
+		flex: 1;
+		padding: 0.5rem 0.75rem;
+		border-radius: 0.6rem;
+		border: 1px solid rgb(255 247 230 / 0.08);
+		font-size: 0.75rem;
+		color: rgb(255 247 230 / 0.5);
+		background: transparent;
+		transition: all 120ms ease;
+	}
+	.settings-pill:hover {
+		color: rgb(255 247 230 / 0.7);
+		border-color: rgb(255 247 230 / 0.2);
+	}
+	.settings-pill--active {
+		background: var(--color-accent, #d4b483);
+		color: #1a1410;
+		border-color: var(--color-accent, #d4b483);
+	}
+	.settings-toggle {
+		display: flex;
+		align-items: center;
+		gap: 0.6rem;
+		font-size: 0.85rem;
+		color: rgb(255 247 230 / 0.7);
+		padding: 0.35rem 0;
+	}
+	.settings-hint {
+		font-size: 0.7rem;
+		color: rgb(255 247 230 / 0.4);
+		margin-top: 0.4rem;
+	}
+</style>

--- a/src/lib/components/books/__tests__/reader-settings.test.ts
+++ b/src/lib/components/books/__tests__/reader-settings.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+	DEFAULT_READER_SETTINGS,
+	loadReaderSettings,
+	persistReaderSettings,
+	resolveSpread,
+	type ReaderSettings
+} from '../reader-settings';
+
+describe('reader-settings', () => {
+	beforeEach(() => {
+		localStorage.clear();
+	});
+
+	it('returns defaults when nothing is stored', () => {
+		expect(loadReaderSettings()).toEqual(DEFAULT_READER_SETTINGS);
+	});
+
+	it('round-trips persisted settings', () => {
+		const patch: Partial<ReaderSettings> = {
+			flow: 'scrolled',
+			spread: 'dual',
+			pageAnimation: 'fade',
+			direction: 'rtl',
+			inputs: { tapZones: false, swipe: true, keyboard: true }
+		};
+		persistReaderSettings(patch);
+		const loaded = loadReaderSettings();
+		expect(loaded.flow).toBe('scrolled');
+		expect(loaded.spread).toBe('dual');
+		expect(loaded.pageAnimation).toBe('fade');
+		expect(loaded.direction).toBe('rtl');
+		expect(loaded.inputs.tapZones).toBe(false);
+	});
+
+	it('preserves unrelated existing fields when persisting a partial patch', () => {
+		persistReaderSettings({ fontSize: 22, theme: 'sepia' as ReaderSettings['theme'] });
+		persistReaderSettings({ flow: 'scrolled' });
+		const loaded = loadReaderSettings();
+		expect(loaded.fontSize).toBe(22);
+		expect(loaded.theme).toBe('sepia');
+		expect(loaded.flow).toBe('scrolled');
+	});
+
+	it('falls back to defaults for missing keys in stored JSON', () => {
+		localStorage.setItem('nexus-reader-settings', JSON.stringify({ flow: 'scrolled' }));
+		const loaded = loadReaderSettings();
+		expect(loaded.flow).toBe('scrolled');
+		expect(loaded.spread).toBe(DEFAULT_READER_SETTINGS.spread);
+		expect(loaded.inputs).toEqual(DEFAULT_READER_SETTINGS.inputs);
+	});
+
+	it('coerces invalid stored values back to defaults', () => {
+		localStorage.setItem('nexus-reader-settings', JSON.stringify({ flow: 'banana', spread: 42 }));
+		const loaded = loadReaderSettings();
+		expect(loaded.flow).toBe(DEFAULT_READER_SETTINGS.flow);
+		expect(loaded.spread).toBe(DEFAULT_READER_SETTINGS.spread);
+	});
+
+	describe('resolveSpread', () => {
+		it('returns single below 768px when auto', () => {
+			expect(resolveSpread('auto', 600)).toBe('single');
+		});
+		it('returns dual at or above 768px when auto', () => {
+			expect(resolveSpread('auto', 1024)).toBe('dual');
+		});
+		it('respects explicit single regardless of width', () => {
+			expect(resolveSpread('single', 1920)).toBe('single');
+		});
+		it('respects explicit dual regardless of width', () => {
+			expect(resolveSpread('dual', 320)).toBe('dual');
+		});
+	});
+});

--- a/src/lib/components/books/__tests__/useReaderInputs.test.ts
+++ b/src/lib/components/books/__tests__/useReaderInputs.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { hitZone, isHorizontalSwipe, mapKeyToAction, flipForRtl } from '../useReaderInputs.svelte';
+
+describe('useReaderInputs helpers', () => {
+	describe('hitZone', () => {
+		it('maps left third to prev', () => {
+			expect(hitZone(50, 1000)).toBe('prev');
+		});
+		it('maps middle third to toggleUI', () => {
+			expect(hitZone(500, 1000)).toBe('toggleUI');
+		});
+		it('maps right third to next', () => {
+			expect(hitZone(900, 1000)).toBe('next');
+		});
+		it('handles small viewports', () => {
+			expect(hitZone(100, 360)).toBe('prev');
+			expect(hitZone(180, 360)).toBe('toggleUI');
+			expect(hitZone(300, 360)).toBe('next');
+		});
+	});
+
+	describe('isHorizontalSwipe', () => {
+		it('returns prev for rightward swipe past threshold', () => {
+			expect(isHorizontalSwipe({ dx: 80, dy: 10 })).toBe('prev');
+		});
+		it('returns next for leftward swipe past threshold', () => {
+			expect(isHorizontalSwipe({ dx: -80, dy: 10 })).toBe('next');
+		});
+		it('returns null when below threshold', () => {
+			expect(isHorizontalSwipe({ dx: 30, dy: 5 })).toBeNull();
+		});
+		it('returns null when vertical travel dominates', () => {
+			expect(isHorizontalSwipe({ dx: 60, dy: 200 })).toBeNull();
+		});
+	});
+
+	describe('mapKeyToAction', () => {
+		it('maps ArrowLeft to prev', () => {
+			expect(mapKeyToAction('ArrowLeft')).toBe('prev');
+		});
+		it('maps ArrowRight to next', () => {
+			expect(mapKeyToAction('ArrowRight')).toBe('next');
+		});
+		it('maps PageUp to prev, PageDown and Space to next', () => {
+			expect(mapKeyToAction('PageUp')).toBe('prev');
+			expect(mapKeyToAction('PageDown')).toBe('next');
+			expect(mapKeyToAction(' ')).toBe('next');
+		});
+		it('returns null for irrelevant keys', () => {
+			expect(mapKeyToAction('a')).toBeNull();
+			expect(mapKeyToAction('Enter')).toBeNull();
+		});
+	});
+
+	describe('flipForRtl', () => {
+		it('swaps prev and next when direction is rtl', () => {
+			expect(flipForRtl('prev', 'rtl')).toBe('next');
+			expect(flipForRtl('next', 'rtl')).toBe('prev');
+			expect(flipForRtl('toggleUI', 'rtl')).toBe('toggleUI');
+		});
+		it('passes through when direction is ltr', () => {
+			expect(flipForRtl('prev', 'ltr')).toBe('prev');
+			expect(flipForRtl('next', 'ltr')).toBe('next');
+		});
+	});
+});

--- a/src/lib/components/books/reader-settings.ts
+++ b/src/lib/components/books/reader-settings.ts
@@ -1,0 +1,115 @@
+export type ReaderThemeName = 'light' | 'dark' | 'sepia' | 'night';
+export type FontFamilyName = 'serif' | 'sans' | 'mono' | 'dyslexic';
+export type MarginName = 'narrow' | 'normal' | 'wide';
+
+export interface ReaderSettings {
+	theme: ReaderThemeName;
+	fontFamily: FontFamilyName;
+	fontSize: number;
+	lineHeight: number;
+	margins: MarginName;
+	textAlign: 'start' | 'justify';
+	flow: 'paginated' | 'scrolled';
+	spread: 'auto' | 'single' | 'dual';
+	pageAnimation: 'slide' | 'fade' | 'none';
+	inputs: {
+		tapZones: boolean;
+		swipe: boolean;
+		keyboard: boolean;
+	};
+	direction: 'ltr' | 'rtl';
+}
+
+export const DEFAULT_READER_SETTINGS: ReaderSettings = {
+	theme: 'dark',
+	fontFamily: 'serif',
+	fontSize: 18,
+	lineHeight: 1.5,
+	margins: 'normal',
+	textAlign: 'start',
+	flow: 'paginated',
+	spread: 'auto',
+	pageAnimation: 'slide',
+	inputs: { tapZones: true, swipe: true, keyboard: true },
+	direction: 'ltr'
+};
+
+const STORAGE_KEY = 'nexus-reader-settings';
+
+const FLOW_VALUES = new Set(['paginated', 'scrolled'] as const);
+const SPREAD_VALUES = new Set(['auto', 'single', 'dual'] as const);
+const ANIM_VALUES = new Set(['slide', 'fade', 'none'] as const);
+const DIR_VALUES = new Set(['ltr', 'rtl'] as const);
+const ALIGN_VALUES = new Set(['start', 'justify'] as const);
+const THEME_VALUES = new Set(['light', 'dark', 'sepia', 'night'] as const);
+const FONT_VALUES = new Set(['serif', 'sans', 'mono', 'dyslexic'] as const);
+const MARGIN_VALUES = new Set(['narrow', 'normal', 'wide'] as const);
+
+function pick<T extends string>(value: unknown, allowed: Set<T>, fallback: T): T {
+	return typeof value === 'string' && allowed.has(value as T) ? (value as T) : fallback;
+}
+
+function pickNumber(value: unknown, fallback: number, min: number, max: number): number {
+	if (typeof value !== 'number' || !Number.isFinite(value)) return fallback;
+	if (value < min || value > max) return fallback;
+	return value;
+}
+
+function pickBool(value: unknown, fallback: boolean): boolean {
+	return typeof value === 'boolean' ? value : fallback;
+}
+
+function coerce(raw: unknown): ReaderSettings {
+	const r = (raw && typeof raw === 'object' ? raw : {}) as Record<string, unknown>;
+	const inputsRaw = (r.inputs && typeof r.inputs === 'object' ? r.inputs : {}) as Record<string, unknown>;
+	return {
+		theme: pick(r.theme, THEME_VALUES, DEFAULT_READER_SETTINGS.theme),
+		fontFamily: pick(r.fontFamily, FONT_VALUES, DEFAULT_READER_SETTINGS.fontFamily),
+		fontSize: pickNumber(r.fontSize, DEFAULT_READER_SETTINGS.fontSize, 10, 36),
+		lineHeight: pickNumber(r.lineHeight, DEFAULT_READER_SETTINGS.lineHeight, 1.0, 2.5),
+		margins: pick(r.margins, MARGIN_VALUES, DEFAULT_READER_SETTINGS.margins),
+		textAlign: pick(r.textAlign, ALIGN_VALUES, DEFAULT_READER_SETTINGS.textAlign),
+		flow: pick(r.flow, FLOW_VALUES, DEFAULT_READER_SETTINGS.flow),
+		spread: pick(r.spread, SPREAD_VALUES, DEFAULT_READER_SETTINGS.spread),
+		pageAnimation: pick(r.pageAnimation, ANIM_VALUES, DEFAULT_READER_SETTINGS.pageAnimation),
+		inputs: {
+			tapZones: pickBool(inputsRaw.tapZones, DEFAULT_READER_SETTINGS.inputs.tapZones),
+			swipe: pickBool(inputsRaw.swipe, DEFAULT_READER_SETTINGS.inputs.swipe),
+			keyboard: pickBool(inputsRaw.keyboard, DEFAULT_READER_SETTINGS.inputs.keyboard)
+		},
+		direction: pick(r.direction, DIR_VALUES, DEFAULT_READER_SETTINGS.direction)
+	};
+}
+
+export function loadReaderSettings(): ReaderSettings {
+	if (typeof localStorage === 'undefined') return { ...DEFAULT_READER_SETTINGS };
+	try {
+		const raw = localStorage.getItem(STORAGE_KEY);
+		if (!raw) return { ...DEFAULT_READER_SETTINGS };
+		return coerce(JSON.parse(raw));
+	} catch {
+		return { ...DEFAULT_READER_SETTINGS };
+	}
+}
+
+export function persistReaderSettings(patch: Partial<ReaderSettings>): void {
+	if (typeof localStorage === 'undefined') return;
+	const current = loadReaderSettings();
+	const next: ReaderSettings = {
+		...current,
+		...patch,
+		inputs: { ...current.inputs, ...(patch.inputs ?? {}) }
+	};
+	try {
+		localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+	} catch {
+		/* quota or privacy mode — ignore */
+	}
+}
+
+const SPREAD_BREAKPOINT_PX = 768;
+
+export function resolveSpread(spread: ReaderSettings['spread'], viewportWidth: number): 'single' | 'dual' {
+	if (spread === 'single' || spread === 'dual') return spread;
+	return viewportWidth >= SPREAD_BREAKPOINT_PX ? 'dual' : 'single';
+}

--- a/src/lib/components/books/reader-settings.ts
+++ b/src/lib/components/books/reader-settings.ts
@@ -1,6 +1,6 @@
-export type ReaderThemeName = 'light' | 'dark' | 'sepia' | 'night';
-export type FontFamilyName = 'serif' | 'sans' | 'mono' | 'dyslexic';
-export type MarginName = 'narrow' | 'normal' | 'wide';
+export type ReaderThemeName = 'light' | 'dark' | 'sepia' | 'oled';
+export type FontFamilyName = 'serif' | 'sans' | 'mono' | 'display';
+export type MarginName = 'narrow' | 'medium' | 'wide';
 
 export interface ReaderSettings {
 	theme: ReaderThemeName;
@@ -25,7 +25,7 @@ export const DEFAULT_READER_SETTINGS: ReaderSettings = {
 	fontFamily: 'serif',
 	fontSize: 18,
 	lineHeight: 1.5,
-	margins: 'normal',
+	margins: 'medium',
 	textAlign: 'start',
 	flow: 'paginated',
 	spread: 'auto',
@@ -41,9 +41,9 @@ const SPREAD_VALUES = new Set(['auto', 'single', 'dual'] as const);
 const ANIM_VALUES = new Set(['slide', 'fade', 'none'] as const);
 const DIR_VALUES = new Set(['ltr', 'rtl'] as const);
 const ALIGN_VALUES = new Set(['start', 'justify'] as const);
-const THEME_VALUES = new Set(['light', 'dark', 'sepia', 'night'] as const);
-const FONT_VALUES = new Set(['serif', 'sans', 'mono', 'dyslexic'] as const);
-const MARGIN_VALUES = new Set(['narrow', 'normal', 'wide'] as const);
+const THEME_VALUES = new Set(['light', 'dark', 'sepia', 'oled'] as const);
+const FONT_VALUES = new Set(['serif', 'sans', 'mono', 'display'] as const);
+const MARGIN_VALUES = new Set(['narrow', 'medium', 'wide'] as const);
 
 function pick<T extends string>(value: unknown, allowed: Set<T>, fallback: T): T {
 	return typeof value === 'string' && allowed.has(value as T) ? (value as T) : fallback;

--- a/src/lib/components/books/useReaderInputs.svelte.ts
+++ b/src/lib/components/books/useReaderInputs.svelte.ts
@@ -1,0 +1,98 @@
+import type { ReaderSettings } from './reader-settings';
+
+export type ReaderAction = 'prev' | 'next' | 'toggleUI';
+
+const SWIPE_MIN_PX = 50;
+const SWIPE_VERTICAL_RATIO = 2; // |dx| must be > 2*|dy|
+
+export function hitZone(x: number, width: number): ReaderAction {
+	const third = width / 3;
+	if (x < third) return 'prev';
+	if (x < 2 * third) return 'toggleUI';
+	return 'next';
+}
+
+export function isHorizontalSwipe({ dx, dy }: { dx: number; dy: number }): ReaderAction | null {
+	if (Math.abs(dx) < SWIPE_MIN_PX) return null;
+	if (Math.abs(dx) <= Math.abs(dy) * SWIPE_VERTICAL_RATIO) return null;
+	return dx > 0 ? 'prev' : 'next';
+}
+
+export function mapKeyToAction(key: string): ReaderAction | null {
+	switch (key) {
+		case 'ArrowLeft':
+		case 'PageUp':
+			return 'prev';
+		case 'ArrowRight':
+		case 'PageDown':
+		case ' ':
+			return 'next';
+		default:
+			return null;
+	}
+}
+
+export function flipForRtl<A extends ReaderAction>(action: A, direction: ReaderSettings['direction']): A {
+	if (direction !== 'rtl') return action;
+	if (action === 'prev') return 'next' as A;
+	if (action === 'next') return 'prev' as A;
+	return action;
+}
+
+interface UseInputsArgs {
+	getSettings: () => Pick<ReaderSettings, 'inputs' | 'direction'>;
+	onPrev: () => void;
+	onNext: () => void;
+	onToggleUI: () => void;
+}
+
+export function useReaderInputs(args: UseInputsArgs) {
+	const dispatch = (action: ReaderAction) => {
+		const { direction } = args.getSettings();
+		const final = flipForRtl(action, direction);
+		if (final === 'prev') args.onPrev();
+		else if (final === 'next') args.onNext();
+		else if (final === 'toggleUI') args.onToggleUI();
+	};
+
+	const tapHandlers = {
+		onpointerup(e: PointerEvent) {
+			if (!args.getSettings().inputs.tapZones) return;
+			const target = e.currentTarget as HTMLElement;
+			const rect = target.getBoundingClientRect();
+			dispatch(hitZone(e.clientX - rect.left, rect.width));
+		}
+	};
+
+	let touchStart: { x: number; y: number } | null = null;
+	const swipeHandlers = {
+		ontouchstart(e: TouchEvent) {
+			if (!args.getSettings().inputs.swipe) return;
+			const t = e.changedTouches[0];
+			touchStart = { x: t.clientX, y: t.clientY };
+		},
+		ontouchend(e: TouchEvent) {
+			if (!args.getSettings().inputs.swipe || !touchStart) return;
+			const t = e.changedTouches[0];
+			const dx = t.clientX - touchStart.x;
+			const dy = t.clientY - touchStart.y;
+			touchStart = null;
+			const action = isHorizontalSwipe({ dx, dy });
+			if (action) dispatch(action);
+		}
+	};
+
+	function attachKeyboard(target: Window | HTMLElement = window): () => void {
+		const onKey = (e: KeyboardEvent) => {
+			if (!args.getSettings().inputs.keyboard) return;
+			const action = mapKeyToAction(e.key);
+			if (!action) return;
+			e.preventDefault();
+			dispatch(action);
+		};
+		target.addEventListener('keydown', onKey as EventListener);
+		return () => target.removeEventListener('keydown', onKey as EventListener);
+	}
+
+	return { tapHandlers, swipeHandlers, attachKeyboard };
+}

--- a/src/routes/books/read/[id]/+page.server.ts
+++ b/src/routes/books/read/[id]/+page.server.ts
@@ -57,10 +57,16 @@ export const load: PageServerLoad = async ({ params, url, locals }) => {
 	// Resume position (EPUB CFI or PDF page) lives in play_sessions.position.
 	const savedPosition: string | undefined = sessionRow?.position ?? undefined;
 
-	// Determine format to read — default to EPUB, allow ?format=pdf etc
+	// Determine format to read — default to EPUB, allow ?format=pdf etc.
+	// Calibre adapter returns metadata.formats as CalibreFormat[] ({name, downloadUrl}),
+	// not string[]. Other adapters could legitimately produce strings, so accept both.
 	const requestedFormat = (url.searchParams.get('format') ?? 'epub').toLowerCase();
-	const availableFormats = (item.metadata?.formats as string[]) ?? [];
-	const format = availableFormats.map(f => f.toLowerCase()).includes(requestedFormat) ? requestedFormat : 'epub';
+	const rawFormats = (item.metadata?.formats as Array<string | { name?: string }> | undefined) ?? [];
+	const availableFormats = rawFormats
+		.map(f => (typeof f === 'string' ? f : f?.name ?? ''))
+		.filter(Boolean)
+		.map(s => s.toLowerCase());
+	const format = availableFormats.includes(requestedFormat) ? requestedFormat : 'epub';
 	const bookUrl = format === 'epub'
 		? `/api/books/${params.id}/read`
 		: `/api/books/${params.id}/download/${format}?view=true`;
@@ -70,7 +76,7 @@ export const load: PageServerLoad = async ({ params, url, locals }) => {
 		serviceId: calibreConfig.id,
 		bookUrl,
 		format,
-		availableFormats: availableFormats.map(f => f.toLowerCase()),
+		availableFormats,
 		savedPosition,
 		progress: sessionRow?.progress ?? 0,
 		bookmarks,

--- a/src/test-setup/localstorage-shim.ts
+++ b/src/test-setup/localstorage-shim.ts
@@ -1,0 +1,45 @@
+// Node 25 ships a native `localStorage` that requires `--localstorage-file=<path>`
+// to function. Inside vitest's jsdom environment, that native stub shadows jsdom's
+// own Storage — leaving `setItem`/`clear`/etc. undefined. This setup file installs
+// a simple Map-backed Storage polyfill so component tests get the DOM behavior
+// they expect without CLI flags. Load order: applied once before each test file
+// that opts into the jsdom environment.
+
+const backing = new Map<string, string>();
+
+const storage: Storage = {
+	get length() {
+		return backing.size;
+	},
+	clear() {
+		backing.clear();
+	},
+	getItem(key: string) {
+		return backing.has(key) ? backing.get(key)! : null;
+	},
+	key(index: number) {
+		return Array.from(backing.keys())[index] ?? null;
+	},
+	removeItem(key: string) {
+		backing.delete(key);
+	},
+	setItem(key: string, value: string) {
+		backing.set(key, String(value));
+	}
+};
+
+Object.defineProperty(globalThis, 'localStorage', {
+	configurable: true,
+	writable: true,
+	value: storage
+});
+
+// Keep window.localStorage and globalThis.localStorage pointing at the same object
+// so code that uses either sees the same data.
+if (typeof window !== 'undefined') {
+	Object.defineProperty(window, 'localStorage', {
+		configurable: true,
+		writable: true,
+		value: storage
+	});
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
 	test: {
 		include: ['src/**/__tests__/**/*.test.ts'],
 		environment: 'node',
+		setupFiles: ['src/test-setup/localstorage-shim.ts'],
 		globals: false,
 		alias: {
 			'$lib': resolve('./src/lib'),


### PR DESCRIPTION
Closes #61.

## Summary
- PDF reader gains paginated mode (was scroll-only). EPUB gains the missing flow/spread/animation/inputs/direction controls.
- Shared `ReaderSettings` model + shared settings UI (`ReaderSettingsPanel`), persisted client-side in `localStorage` under the existing `nexus-reader-settings` key.
- New components: `PaginatedViewport` (generic wrapper), `useReaderInputs` rune (tap zones / swipe / keyboard with RTL flip), `ReaderSettingsPanel`.
- Animations: slide / fade / none (no page-curl).
- PDF toolbar gains a Reader Settings gear button (otherwise no entry point in scrolled mode).
- Bug fix: `/books/read/[id]/+page.server.ts` no longer crashes when `metadata.formats` are `CalibreFormat` objects (it always was — `.toLowerCase()` on an object), and no longer defaults to EPUB when EPUB isn't an available format.

Spec: `docs/superpowers/specs/2026-04-19-reader-paginated-mode-design.md`
Plan: `docs/superpowers/plans/2026-04-19-reader-paginated-mode.md`

## What was harder than expected
- `bind:this` with array indexing inside Svelte 5 snippets is fragile — the slot can read empty even when the canvas is mounted. Switched to a `use:onCanvasMount` action that caches the ref into the array directly and kicks off render via `queueMicrotask` (RAF gets cancelled by the action's lifecycle during commit).
- `PaginatedViewport`'s original `{#key animationKey}` wrap killed the EPUB iframe each navigation (foliate-js's `addEventListener.once` then hit a null `contentDocument`). Removed the key wrap; PDF still re-mounts naturally on `currentPage` change so animations still play.
- Paginated dual mode rendered each page at single-page-fit-width scale → pages overflowed (page 1 at x=-370). Now fit-to-viewport, divided by `pagesAcross`.
- Zoom in/out in paginated mode didn't take while a page was mid-render — `invalidateAllPages` only iterated `renderedPages` (finished), not `renderingPages` (in-flight). Fixed by iterating the union so the active task gets cancelled.
- T5 implementer renamed BookReader's existing `oled`/`display`/`medium` keys to match a stale plan, which would silently reset existing users' stored settings; reverted to the original keys.

## Out of scope (per spec, intentional)
- Page-curl animation, per-zone tap remapping, two-up cover handling, per-book settings overrides.
- W (fit-width) / P (fit-page) toolbar buttons in PDF — they remain scrolled-mode-only since paginated already auto-fits. Can hide them in a follow-up if the dead buttons confuse.

## Test plan
- [ ] Open an EPUB at `/books/read/<id>` — paginated mode renders, settings drawer has new controls
- [ ] Toggle Flow → Scrolled, verify behavior changes
- [ ] Open a PDF — paginated mode renders, gear icon opens settings drawer
- [ ] Single ↔ Dual spread toggle works for PDF
- [ ] Zoom in/out works in PDF paginated mode (canvas grows/shrinks)
- [ ] ArrowLeft/Right and Space advance pages in both readers
- [ ] Direction → RTL inverts swipe and tap-zone semantics
- [ ] Settings persist across reload

`pnpm check` clean, `pnpm vitest run` 161/161 passing, `pnpm build` succeeds. Verified live on jellyfin host via `:dev` build through the entire iteration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)