### PR TITLE
fix: codex review batch — history links, thumbnails, music transcode, calibre, SQL params

### DIFF
--- a/src/lib/components/history/HistoryFeed.svelte
+++ b/src/lib/components/history/HistoryFeed.svelte
@@ -99,7 +99,7 @@
 						{@const progress = event.progress != null ? `${Math.round(event.progress * 100)}%` : null}
 						{@const poster = posterUrl(event)}
 						<a
-							href="/media/{event.mediaType}/{event.serviceId}:{event.mediaId}"
+							href="/media/{event.mediaType}/{event.mediaId}?service={event.serviceId}"
 							class="flex items-center gap-3 rounded-lg bg-cream/[0.02] p-2.5 transition-colors hover:bg-cream/[0.04]"
 						>
 							{#if poster}

--- a/src/lib/server/stats-engine.ts
+++ b/src/lib/server/stats-engine.ts
@@ -137,17 +137,27 @@ export interface ComputedStats {
 export function computeStats(userId: string, from: number, to: number, mediaType?: string): ComputedStats {
 	const db = getRawDb();
 
-	const mediaTypeFilter = mediaType && mediaType !== 'all' ? ` AND media_type = '${mediaType}'` : '';
-
-	// Query play_sessions directly — one row per session, no dedup needed
-	const sessions = db.prepare(`
-		SELECT media_id, media_title, media_type, duration_ms, media_duration_ms, media_genres,
-		       device_name, client_name, metadata, started_at, completed
-		FROM play_sessions
-		WHERE user_id = ? AND started_at >= ? AND started_at < ?${mediaTypeFilter}
-		ORDER BY started_at ASC
-		LIMIT 50000
-	`).all(userId, from, to) as any[];
+	const filterByMediaType = Boolean(mediaType) && mediaType !== 'all';
+	// Parameterize the media_type filter rather than interpolating user-controllable
+	// input into SQL. Callers today funnel trusted-ish values, but the `type` query
+	// param on /api/user/stats reaches here directly — defense-in-depth required.
+	const sessions = (filterByMediaType
+		? db.prepare(`
+			SELECT media_id, media_title, media_type, duration_ms, media_duration_ms, media_genres,
+			       device_name, client_name, metadata, started_at, completed
+			FROM play_sessions
+			WHERE user_id = ? AND started_at >= ? AND started_at < ? AND media_type = ?
+			ORDER BY started_at ASC
+			LIMIT 50000
+		`).all(userId, from, to, mediaType)
+		: db.prepare(`
+			SELECT media_id, media_title, media_type, duration_ms, media_duration_ms, media_genres,
+			       device_name, client_name, metadata, started_at, completed
+			FROM play_sessions
+			WHERE user_id = ? AND started_at >= ? AND started_at < ?
+			ORDER BY started_at ASC
+			LIMIT 50000
+		`).all(userId, from, to)) as any[];
 
 	// Completions from the completed column
 	const completions = sessions.filter((s: any) => s.completed === 1).length;

--- a/src/lib/stores/musicStore.svelte.ts
+++ b/src/lib/stores/musicStore.svelte.ts
@@ -78,7 +78,7 @@ if (browser) initAudio();
 
 function loadAndPlay(track: Track) {
 	if (!audioElement) return;
-	const streamUrl = `/api/stream/${track.serviceId}/audio/${track.sourceId}/universal?Container=opus,mp3,aac&AudioCodec=opus&TranscodingContainer=ts&MaxStreamingBitrate=320000`;
+	const streamUrl = `/api/stream/${track.serviceId}/audio/${track.sourceId}/universal?Container=opus,mp3,aac&AudioCodec=opus&TranscodingContainer=aac&MaxStreamingBitrate=320000`;
 	audioElement.src = streamUrl;
 	audioElement.play().catch((e) => console.error('[music] Play failed:', e));
 	_playing = true;


### PR DESCRIPTION
## Summary

Batch of codex review fixes from April 2026 that were implemented in agent worktrees but never pushed or merged. Rolled up via `fix/music-transcode-container-apr17`:

- **A9** — history feed link format matches canonical `/media/` shape
- **A10** — history thumbnails resolve per-service, not hardcoded Jellyfin
- **A12** — music transcode container: align client/server
- **A15** (security) — parameterize `computeStats` mediaType to prevent SQL injection
- **#27** — distinguish empty Calibre library from failed load

Individual fix branches also pushed separately for reference:
- `fix/history-feed-link-format-apr17`
- `fix/compute-stats-sql-params-apr17`
- `fix/history-thumbnail-paths-apr17`
- `fix/calibre-books-investigation-apr17`

## Test plan
- [ ] History feed links navigate to correct `/media/` paths
- [ ] History thumbnails load for non-Jellyfin services (Plex, etc.)
- [ ] Music transcoding works end-to-end
- [ ] `computeStats` queries are parameterized (no raw interpolation)
- [ ] Empty Calibre library shows "empty" state, not error

🤖 Generated with [Claude Code](https://claude.com/claude-code)